### PR TITLE
Use abstract even loop/polling service.

### DIFF
--- a/zeroconf/src/browser.rs
+++ b/zeroconf/src/browser.rs
@@ -1,11 +1,13 @@
 //! Trait definition for cross-platform browser
 
-use crate::{EventLoop, NetworkInterface, Result, TxtRecord};
+use crate::{NetworkInterface, Result, TxtRecord, TNewPoll, TPoll};
+use crate::event_loop::TEventLoop;
 use std::any::Any;
 use std::sync::Arc;
+use std::fmt;
 
 /// Interface for interacting with underlying mDNS implementation service browsing capabilities.
-pub trait TMdnsBrowser {
+pub trait TMdnsBrowser<Poll> {
     /// Creates a new `MdnsBrowser` that browses for the specified `kind` (e.g. `_http._tcp`)
     fn new(kind: &str) -> Self;
 
@@ -29,7 +31,11 @@ pub trait TMdnsBrowser {
     fn set_context(&mut self, context: Box<dyn Any>);
 
     /// Starts the browser. Returns an `EventLoop` which can be called to keep the browser alive.
-    fn browse_services(&mut self) -> Result<EventLoop>;
+    fn browse_services(&mut self) -> Result<Poll>
+        where Poll: TNewPoll + TEventLoop + Clone + fmt::Debug;
+
+    fn browse_services_with_poll(&mut self, poll: Poll) -> Result<()>
+        where Poll: TPoll + fmt::Debug;
 }
 
 /// Callback invoked from [`MdnsBrowser`] once a service has been discovered and resolved.

--- a/zeroconf/src/lib.rs
+++ b/zeroconf/src/lib.rs
@@ -156,14 +156,21 @@ pub use service::{ServiceRegisteredCallback, ServiceRegistration};
 
 /// Type alias for the platform-specific mDNS browser implementation
 #[cfg(target_os = "linux")]
-pub type MdnsBrowser = linux::browser::AvahiMdnsBrowser;
+pub type MdnsBrowser<Poll> = linux::browser::AvahiMdnsBrowser<Poll>;
+
+/// Simple MdnsBrowser based on Avahi simple poll.
+#[cfg(target_os = "linux")]
+pub type SimpleMdnsBrowser = linux::browser::SimpleAvahiMdnsBrowser;
+
 /// Type alias for the platform-specific mDNS browser implementation
 #[cfg(target_os = "macos")]
 pub type MdnsBrowser = macos::browser::BonjourMdnsBrowser;
 
 /// Type alias for the platform-specific mDNS service implementation
 #[cfg(target_os = "linux")]
-pub type MdnsService = linux::service::AvahiMdnsService;
+pub type MdnsService<Loop> = linux::service::AvahiMdnsService<Loop>;
+#[cfg(target_os = "linux")]
+pub type SimpleMdnsService = linux::service::SimpleAvahiMdnsService;
 /// Type alias for the platform-specific mDNS service implementation
 #[cfg(target_os = "macos")]
 pub type MdnsService = macos::service::BonjourMdnsService;
@@ -186,3 +193,10 @@ pub type TxtRecord = macos::txt_record::BonjourTxtRecord;
 
 /// Result type for this library
 pub type Result<T> = std::result::Result<T, error::Error>;
+
+// TODO: Make a MacOS version of this too!
+#[cfg(target_os = "linux")]
+pub use linux::poll::TPoll;
+
+#[cfg(target_os = "linux")]
+pub use linux::poll::TNewPoll;

--- a/zeroconf/src/linux/event_loop.rs
+++ b/zeroconf/src/linux/event_loop.rs
@@ -1,12 +1,18 @@
 //! Event loop for running a `MdnsService` or `MdnsBrowser`.
 
-use super::poll::ManagedAvahiSimplePoll;
+use super::poll::{
+    ManagedAvahiSimplePoll,
+    TPoll,
+    TNewPoll,
+};
 use crate::event_loop::TEventLoop;
 use crate::Result;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[derive(new)]
+use avahi_sys::AvahiPoll;
+
+#[derive(new,Clone)]
 pub struct AvahiEventLoop {
     poll: Arc<ManagedAvahiSimplePoll>,
 }
@@ -19,5 +25,20 @@ impl TEventLoop for AvahiEventLoop {
     fn poll(&self, _timeout: Duration) -> Result<()> {
         self.poll.iterate(0);
         Ok(())
+    }
+}
+
+impl TPoll for AvahiEventLoop {
+    fn as_avahi_poll(&self) -> *const AvahiPoll {
+        self.poll.as_avahi_poll()
+    }
+}
+
+impl TNewPoll for AvahiEventLoop {
+    fn new() -> Result<Self> {
+        Ok(AvahiEventLoop {
+            poll: Arc::new(ManagedAvahiSimplePoll::new()?),
+        }
+        )
     }
 }

--- a/zeroconf/src/linux/poll.rs
+++ b/zeroconf/src/linux/poll.rs
@@ -3,8 +3,37 @@
 use crate::Result;
 use avahi_sys::{
     avahi_simple_poll_free, avahi_simple_poll_iterate, avahi_simple_poll_loop,
-    avahi_simple_poll_new, AvahiSimplePoll,
+    avahi_simple_poll_new, AvahiSimplePoll, AvahiPoll
 };
+
+
+/// Platform specific trait providing a polling service.
+///
+/// The service provides the means for waiting asynchronously for events like
+/// ready file descriptors. Avahi does this by the means of the `AvahiPoll`
+/// abstraction, Bonjour apparently just polls a single file descriptor.
+///
+/// User code should treat this as an abstract trait, except when different
+/// means for polling should be provided (e.g. integration with some async
+/// framework) , in this case the user should provide an implementation for each
+/// platform she cares about and use it with
+/// `Service::register_with_poll` for example in order to integrate with some
+/// other event loop implementation or async framework. This type should then
+/// also implement the platform independent `TEventLoop` trait.
+pub trait TPoll {
+    fn as_avahi_poll(&self) -> *const AvahiPoll;
+    // fn as_avahi_poll_mut(&mut self) -> *mut AvahiPoll;
+}
+
+/// Make a type suitable for `Service::register`.
+///
+/// Any type that works without any external dependencies should be able to
+/// implement this trait and thus makes the simple `Service::register`
+/// available to users.
+pub trait TNewPoll: TPoll {
+    fn new() -> Result<Self>
+        where Self: std::marker::Sized;
+}
 
 /// Wraps the `AvahiSimplePoll` type from the raw Avahi bindings.
 ///
@@ -40,6 +69,21 @@ impl ManagedAvahiSimplePoll {
     /// [`avahi_simple_poll_iterate()`]: https://avahi.org/doxygen/html/simple-watch_8h.html#ad5b7c9d3b7a6584d609241ee6f472a2e
     pub fn iterate(&self, sleep_time: i32) {
         unsafe { avahi_simple_poll_iterate(self.0, sleep_time) };
+    }
+}
+
+impl TPoll for ManagedAvahiSimplePoll {
+    fn as_avahi_poll(&self) -> *const AvahiPoll {
+        self.0 as *const AvahiPoll
+    }
+    // fn as_avahi_poll_mut(mut& self) -> *mut AvahiPoll {
+    //     self.0 as *mut AvahiPoll
+    // }
+}
+
+impl TNewPoll for ManagedAvahiSimplePoll {
+    fn new() -> Result<Self> {
+        ManagedAvahiSimplePoll::new()
     }
 }
 

--- a/zeroconf/src/service.rs
+++ b/zeroconf/src/service.rs
@@ -1,12 +1,18 @@
 //! Trait definition for cross-platform service.
 
-use crate::{EventLoop, NetworkInterface, Result, TxtRecord};
+use crate::{
+    NetworkInterface, Result, TxtRecord,
+    TPoll, TNewPoll,
+    event_loop::TEventLoop,
+};
+
 use std::any::Any;
 use std::sync::Arc;
+use std::fmt;
 
 /// Interface for interacting with underlying mDNS service implementation registration
 /// capabilities.
-pub trait TMdnsService {
+pub trait TMdnsService<Poll> {
     /// Creates a new `MdnsService` with the specified `kind` (e.g. `_http._tcp`) and `port`.
     fn new(kind: &str, port: u16) -> Self;
 
@@ -46,7 +52,14 @@ pub trait TMdnsService {
 
     /// Registers and start's the service. Returns an `EventLoop` which can be called to keep
     /// the service alive.
-    fn register(&mut self) -> Result<EventLoop>;
+    fn register(&mut self) -> Result<Poll>
+        where Poll: TNewPoll + TEventLoop + Clone + fmt::Debug;
+
+    /// Register the service with an external provided event loop.
+    ///
+    /// This allows for multiple services or browsers to use the same loop.
+    fn register_with_poll(&mut self, poll: Poll) -> Result<()>
+        where Poll: TPoll + fmt::Debug;
 }
 
 /// Callback invoked from [`MdnsService`] once it has successfully registered.


### PR DESCRIPTION
This allows for replacing it with one that works well with async
frameworks in Rust.

TODO:

1. Implement this also on Mac
2. Think about getting rid of `TMdnsService::register` and replace it
with `TMdnsService::register_with_poll`, this would allow for getting
rid of the new generic `Poll` type parameter and instead using a
modified `AvahiEventLoop` directly, which wraps a plain `AvahiPoll`
instead of an `AvahiSimplePoll`.

Also this is still completely untested - I have a zeroconf-async repo which is also finished code wise, but is also not yet tested at all. Just saying, in case someone is interested before I get to it ;-)