### PR TITLE
Fix service discovery on macOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,31 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  macOS:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare
+      run: "sudo apt -y install avahi-daemon libavahi-client-dev && sudo systemctl start avahi-daemon.service"
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/zeroconf/Cargo.toml
+++ b/zeroconf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroconf"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Walker Crouse <walkercrouse@hotmail.com>"]
 edition = "2018"
 description = "cross-platform library that wraps ZeroConf/mDNS implementations like Bonjour or Avahi"

--- a/zeroconf/src/ffi/mod.rs
+++ b/zeroconf/src/ffi/mod.rs
@@ -1,9 +1,9 @@
 //! Utilities related to FFI bindings
 
 use crate::Result;
-use libc::{c_void, fd_set, timeval};
 #[cfg(target_os = "linux")]
 use libc::{c_char, in_addr, sockaddr_in};
+use libc::{c_void, fd_set, timeval};
 use std::time::Duration;
 use std::{mem, ptr};
 

--- a/zeroconf/src/ffi/mod.rs
+++ b/zeroconf/src/ffi/mod.rs
@@ -1,7 +1,9 @@
 //! Utilities related to FFI bindings
 
 use crate::Result;
-use libc::{c_char, c_void, fd_set, in_addr, sockaddr_in, timeval};
+use libc::{c_void, fd_set, timeval};
+#[cfg(target_os = "linux")]
+use libc::{c_char, in_addr, sockaddr_in};
 use std::time::Duration;
 use std::{mem, ptr};
 
@@ -103,12 +105,14 @@ impl<T> UnwrapMutOrNull<T> for Option<*mut T> {
 ///
 /// # Safety
 /// This function is unsafe because of calls to C-library system calls
+#[cfg(target_os = "linux")]
 pub unsafe fn get_ip(address: *const sockaddr_in) -> String {
     assert_not_null!(address);
     let raw = inet_ntoa(&(*address).sin_addr as *const in_addr);
     String::from(c_str::raw_to_str(raw))
 }
 
+#[cfg(target_os = "linux")]
 extern "C" {
     fn inet_ntoa(addr: *const in_addr) -> *const c_char;
 }

--- a/zeroconf/src/macos/browser.rs
+++ b/zeroconf/src/macos/browser.rs
@@ -252,7 +252,7 @@ unsafe fn handle_get_address_info(
     }
 
     // on macOS the bytes are swapped for the port
-    let port :u16 = ctx.resolved_port.to_be();
+    let port: u16 = ctx.resolved_port.to_be();
 
     // on macOS the bytes are swapped for the ip
     let ip = {

--- a/zeroconf/src/macos/browser.rs
+++ b/zeroconf/src/macos/browser.rs
@@ -5,8 +5,6 @@ use super::service_ref::{
 };
 use super::txt_record_ref::ManagedTXTRecordRef;
 use super::{bonjour_util, constants};
-#[cfg(target_os = "linux")]
-use crate::ffi::self;
 use crate::ffi::{c_str, AsRaw, FromRaw};
 use crate::prelude::*;
 use crate::{EventLoop, NetworkInterface, Result, TxtRecord};
@@ -254,15 +252,9 @@ unsafe fn handle_get_address_info(
     }
 
     // on macOS the bytes are swapped for the port
-    #[cfg(target_os = "linux")]
-    let port :u16 = ctx.resolved_port;
-    #[cfg(target_os = "macos")]
     let port :u16 = ctx.resolved_port.to_be();
 
     // on macOS the bytes are swapped for the ip
-    #[cfg(target_os = "linux")]
-    let ip = ffi::get_ip(address as *const sockaddr_in);
-    #[cfg(target_os = "macos")]
     let ip = {
         let address = address as *const sockaddr_in;
         assert_not_null!(address);

--- a/zeroconf/src/macos/browser.rs
+++ b/zeroconf/src/macos/browser.rs
@@ -210,7 +210,7 @@ unsafe fn handle_resolve(
         GetAddressInfoParams::builder()
             .flags(bonjour_sys::kDNSServiceFlagsForceMulticast)
             .interface_index(interface_index)
-            .protocol(1)
+            .protocol(0)
             .hostname(host_target)
             .callback(Some(get_address_info_callback))
             .context(ctx.as_raw())

--- a/zeroconf/src/macos/browser.rs
+++ b/zeroconf/src/macos/browser.rs
@@ -208,7 +208,7 @@ unsafe fn handle_resolve(
         GetAddressInfoParams::builder()
             .flags(bonjour_sys::kDNSServiceFlagsForceMulticast)
             .interface_index(interface_index)
-            .protocol(0)
+            .protocol(1)
             .hostname(host_target)
             .callback(Some(get_address_info_callback))
             .context(ctx.as_raw())

--- a/zeroconf/src/macos/browser.rs
+++ b/zeroconf/src/macos/browser.rs
@@ -206,9 +206,6 @@ unsafe fn handle_resolve(
         None
     };
 
-    println!("host_target: {}", c_str::copy_raw(host_target));
-    println!("interface_index: {}", interface_index);
-
     ManagedDNSServiceRef::default().get_address_info(
         GetAddressInfoParams::builder()
             .flags(bonjour_sys::kDNSServiceFlagsForceMulticast)


### PR DESCRIPTION
# Problem
I have some problems with the service discovery using version `0.6.2` on macOS. It can be reproduced by running the browser example on macOS. I changed the search term to `_googlecast._tcp` (because I have one) and got the following result.

```rust
Service discovered: ServiceDiscovery { name: "Chromecast-d17b7612bf302156649b47d71759c75d", kind: "_googlecast._tcp.", domain: "local", host_name: "d17b7612-bf30-2156-649b-47d71759c75d.local.", address: "100.113.246.228", port: 18719, txt: Some(BonjourTxtRecord(ManagedTXTRecordRef)) }
```

The resulting IP and Port are just wrong, and the IP even change from execution to execution. The correct and expected values are `address: "192.168.178.51", port: 8009`.

# Environment

* **macOS** *Big Sur 11.1*
* **rustc** *rustc 1.49.0 (e1884a8e3 2020-12-29)*
* **toolchain** *stable-x86_64-apple-darwin*

# Solution in the PR
I debuged the code and found out that for the u32, which represents the IP, and the u16, which represent the Port, the endianess is messed up. The IP seem to use [host byte order](https://www.gnu.org/software/libc/manual/html_node/Host-Address-Functions.html) which is the reason why `inet_ntoa` is returning the wrong result. The Port is also just using the wrong byte order and a simple conversion to big endian is doing the trick.

As this solution is working for me I'm still not sure why this is happening. It seems like the bonjour implementation isn't compatible with libc and also the conversion from the u16 port value into rust isn't working. I also wasn't able to find something about it somewhere in the internet what gives this solution a bit of uncertainty.
