### PR TITLE
timeval: use libc types for tv_sec and tv_usec

### DIFF
--- a/zeroconf/src/ffi/mod.rs
+++ b/zeroconf/src/ffi/mod.rs
@@ -3,7 +3,7 @@
 use crate::Result;
 #[cfg(target_os = "linux")]
 use libc::{c_char, in_addr, sockaddr_in};
-use libc::{c_void, fd_set, timeval};
+use libc::{c_void, fd_set, timeval, time_t, suseconds_t};
 use std::time::Duration;
 use std::{mem, ptr};
 
@@ -54,12 +54,8 @@ pub unsafe fn read_select(sock_fd: i32, timeout: Duration) -> Result<u32> {
     libc::FD_ZERO(&mut read_flags);
     libc::FD_SET(sock_fd, &mut read_flags);
 
-    let tv_sec = timeout.as_secs() as i64;
-    #[cfg(target_vendor = "apple")]
-    let tv_usec = timeout.subsec_micros() as i32;
-    #[cfg(target_os = "linux")]
-    let tv_usec = timeout.subsec_micros() as i64;
-
+    let tv_sec = timeout.as_secs() as time_t;
+    let tv_usec = timeout.subsec_micros() as suseconds_t;
     let mut timeout = timeval { tv_sec, tv_usec };
 
     let result = libc::select(


### PR DESCRIPTION
Background: I was trying to build an application that depends on this crate for a 32-bit ARM platform (`arm-unknown-linux-gnueabihf` target in Rust). The library failed to build because it was expecting the `tv_sec` and `tv_usec` members of `timeval` to be of type `i64` when they are in fact `i32` on that target.

I see there are already some cfg conditionals in the code to work around different timeval types on different platforms. I think a more universal solution would be to use the types that the `libc` crate defines for the timeval struct members directly: https://docs.rs/libc/0.2.94/libc/struct.timeval.html. I tested this and it makes the library build correctly for my target; however, there may be some issue with this on another platform that I'm not aware of. Happy to modify if so.

Thanks!

