### PR TITLE
Fix incorrect port numbers being registered for services on macOS.

### DIFF
--- a/zeroconf/src/macos/service_ref.rs
+++ b/zeroconf/src/macos/service_ref.rs
@@ -56,7 +56,7 @@ impl ManagedDNSServiceRef {
                 regtype,
                 domain,
                 host,
-                port,
+                port.to_be(),
                 txt_len,
                 txt_record,
                 callback,


### PR DESCRIPTION
Per https://developer.apple.com/documentation/dnssd/1804733-dnsserviceregister,
`DNSServiceRegister()` takes the port number in network byte order. This fixes
the bug with wrong ports being registered on macOS.