### PR TITLE
Respect poll timeout on linux

### DIFF
--- a/zeroconf/src/linux/browser.rs
+++ b/zeroconf/src/linux/browser.rs
@@ -127,6 +127,7 @@ impl AvahiBrowserContext {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for AvahiBrowserContext {
     fn default() -> Self {
         AvahiBrowserContext {

--- a/zeroconf/src/linux/event_loop.rs
+++ b/zeroconf/src/linux/event_loop.rs
@@ -16,10 +16,11 @@ pub struct AvahiEventLoop<'a> {
 impl<'a> TEventLoop for AvahiEventLoop<'a> {
     /// Polls for new events.
     ///
-    /// Internally calls `ManagedAvahiSimplePoll::iterate(0)`, the `timeout` parameter does not
-    /// currently do anything in the Avahi implementation.
-    fn poll(&self, _timeout: Duration) -> Result<()> {
-        self.poll.iterate(0);
-        Ok(())
+    /// Internally calls `ManagedAvahiSimplePoll::iterate(..)`.  
+    /// In systems where the C implementation of `poll(.., timeout)`
+    /// does not respect the `timeout` parameter, the `timeout` passed
+    /// here will have no effect -- ie will return immediately.
+    fn poll(&self, timeout: Duration) -> Result<()> {
+        self.poll.iterate(timeout)
     }
 }

--- a/zeroconf/src/tests/event_loop_test.rs
+++ b/zeroconf/src/tests/event_loop_test.rs
@@ -1,0 +1,85 @@
+use crate::prelude::*;
+use crate::{MdnsService, ServiceType, TxtRecord};
+use std::time::{Duration, Instant};
+
+const TEST_DURATION: Duration = Duration::from_secs(1);
+
+const FAST_SPIN_TIMEOUT: Duration = Duration::from_secs(0);
+const FAST_SPIN_MIN_ITERS: u32 = 10_000;
+
+const LONG_POLL_TIMEOUT: Duration = Duration::from_secs(1);
+const LONG_POLL_MAX_ITERS: u32 = 100;
+
+#[test]
+fn event_loop_spins_fast() {
+    super::setup();
+
+    static SERVICE_NAME: &str = "event_loop_test_service";
+    let mut service = MdnsService::new(ServiceType::new("http", "tcp").unwrap(), 8080);
+
+    let mut txt = TxtRecord::new();
+    txt.insert("foo", "bar").unwrap();
+
+    service.set_name(SERVICE_NAME);
+    service.set_txt_record(txt.clone());
+    service.set_registered_callback(Box::new(|_, _| {
+        debug!("Service published");
+    }));
+
+    let start = Instant::now();
+    let mut iterations = 0;
+    let event_loop = service.register().unwrap();
+    loop {
+        event_loop.poll(FAST_SPIN_TIMEOUT).unwrap();
+
+        if Instant::now().saturating_duration_since(start) >= TEST_DURATION {
+            break;
+        }
+        iterations += 1;
+    }
+
+    println!(
+        "service loop spun {} times in {} sec",
+        iterations,
+        TEST_DURATION.as_secs()
+    );
+
+    assert!(iterations > FAST_SPIN_MIN_ITERS);
+}
+
+#[test]
+fn event_loop_long_polls() {
+    super::setup();
+
+    static SERVICE_NAME: &str = "event_loop_test_service";
+    let mut service = MdnsService::new(ServiceType::new("http", "tcp").unwrap(), 8080);
+
+    let mut txt = TxtRecord::new();
+    txt.insert("foo", "bar").unwrap();
+
+    service.set_name(SERVICE_NAME);
+    service.set_txt_record(txt.clone());
+    service.set_registered_callback(Box::new(|_, _| {
+        debug!("Service published");
+    }));
+
+    let start = Instant::now();
+    let mut iterations = 0;
+    let event_loop = service.register().unwrap();
+    loop {
+        event_loop.poll(LONG_POLL_TIMEOUT).unwrap();
+
+        if Instant::now().saturating_duration_since(start) >= TEST_DURATION {
+            break;
+        }
+        iterations += 1;
+    }
+
+    println!(
+        "service loop spun {} times in {} sec",
+        iterations,
+        TEST_DURATION.as_secs()
+    );
+
+    assert!(LONG_POLL_MAX_ITERS > iterations);
+}

--- a/zeroconf/src/tests/mod.rs
+++ b/zeroconf/src/tests/mod.rs
@@ -6,5 +6,6 @@ pub(crate) fn setup() {
     INIT.call_once(env_logger::init);
 }
 
+mod event_loop_test;
 mod service_test;
 mod txt_record_test;


### PR DESCRIPTION
Updates 'linux/event_loop.rs' so we pass through the `timeout` to `self.poll.iterate(..)` rather than using a hardcoded 'zero timeout'. 
Also adds some test cases to loosely ensure that using a 'zero timeout' in a loop does result in a CPU hogging tight loop, and using a 'long poll' does result in as few iterations as possible (Im seeing ~1.8-2mil iterations/sec with 'zero timeout', and about 8 iterations/sec with a 1 sec timeout on my ubuntu VM).