### PR TITLE
Add support for subtypes

### DIFF
--- a/zeroconf/src/ffi/mod.rs
+++ b/zeroconf/src/ffi/mod.rs
@@ -47,7 +47,7 @@ pub trait UnwrapOrNull<T> {
 
 impl<T> UnwrapOrNull<T> for Option<*const T> {
     fn unwrap_or_null(&self) -> *const T {
-        self.unwrap_or_else(|| ptr::null() as *const T)
+        self.unwrap_or_else(ptr::null)
     }
 }
 
@@ -59,7 +59,7 @@ pub trait UnwrapMutOrNull<T> {
 
 impl<T> UnwrapMutOrNull<T> for Option<*mut T> {
     fn unwrap_mut_or_null(&mut self) -> *mut T {
-        self.unwrap_or_else(|| ptr::null_mut() as *mut T)
+        self.unwrap_or_else(ptr::null_mut)
     }
 }
 

--- a/zeroconf/src/linux/browser.rs
+++ b/zeroconf/src/linux/browser.rs
@@ -41,11 +41,16 @@ pub struct AvahiMdnsBrowser {
 
 impl TMdnsBrowser for AvahiMdnsBrowser {
     fn new(service_type: ServiceType) -> Self {
+        let kind = if service_type.sub_types().is_empty() {
+            c_string!(service_type.to_string())
+        } else {
+            c_string!(service_type.sub_types()[0].to_string())
+        };
         Self {
             client: None,
             poll: None,
             browser: None,
-            kind: c_string!(service_type.to_string()),
+            kind,
             context: Box::default(),
             interface_index: avahi_sys::AVAHI_IF_UNSPEC,
         }

--- a/zeroconf/src/linux/client.rs
+++ b/zeroconf/src/linux/client.rs
@@ -1,6 +1,6 @@
 //! Rust friendly `AvahiClient` wrappers/helpers
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use super::avahi_util;
 use super::poll::ManagedAvahiSimplePoll;
@@ -19,7 +19,7 @@ use libc::{c_int, c_void};
 #[derive(Debug)]
 pub struct ManagedAvahiClient {
     pub(crate) inner: *mut AvahiClient,
-    _poll: Arc<ManagedAvahiSimplePoll>,
+    _poll: Rc<ManagedAvahiSimplePoll>,
 }
 
 impl ManagedAvahiClient {
@@ -80,7 +80,7 @@ impl Drop for ManagedAvahiClient {
 /// [`avahi_client_new()`]: https://avahi.org/doxygen/html/client_8h.html#a07b2a33a3e7cbb18a0eb9d00eade6ae6
 #[derive(Builder, BuilderDelegate)]
 pub struct ManagedAvahiClientParams {
-    poll: Arc<ManagedAvahiSimplePoll>,
+    poll: Rc<ManagedAvahiSimplePoll>,
     flags: AvahiClientFlags,
     callback: AvahiClientCallback,
     userdata: *mut c_void,

--- a/zeroconf/src/linux/entry_group.rs
+++ b/zeroconf/src/linux/entry_group.rs
@@ -1,6 +1,6 @@
 //! Rust friendly `AvahiEntryGroup` wrappers/helpers
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use super::{client::ManagedAvahiClient, string_list::ManagedAvahiStringList};
 use crate::ffi::UnwrapMutOrNull;
@@ -21,7 +21,7 @@ use libc::{c_char, c_void};
 #[derive(Debug)]
 pub struct ManagedAvahiEntryGroup {
     inner: *mut AvahiEntryGroup,
-    _client: Arc<ManagedAvahiClient>,
+    _client: Rc<ManagedAvahiClient>,
 }
 
 impl ManagedAvahiEntryGroup {
@@ -153,7 +153,7 @@ impl Drop for ManagedAvahiEntryGroup {
 /// [avahi_entry_group_new()]: https://avahi.org/doxygen/html/publish_8h.html#abb17598f2b6ec3c3f69defdd488d568c
 #[derive(Builder, BuilderDelegate)]
 pub struct ManagedAvahiEntryGroupParams {
-    client: Arc<ManagedAvahiClient>,
+    client: Rc<ManagedAvahiClient>,
     callback: AvahiEntryGroupCallback,
     userdata: *mut c_void,
 }

--- a/zeroconf/src/linux/event_loop.rs
+++ b/zeroconf/src/linux/event_loop.rs
@@ -4,12 +4,12 @@ use super::poll::ManagedAvahiSimplePoll;
 use crate::event_loop::TEventLoop;
 use crate::Result;
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::rc::Rc;
 use std::time::Duration;
 
 #[derive(new)]
 pub struct AvahiEventLoop<'a> {
-    poll: Arc<ManagedAvahiSimplePoll>,
+    poll: Rc<ManagedAvahiSimplePoll>,
     phantom: PhantomData<&'a ManagedAvahiSimplePoll>,
 }
 

--- a/zeroconf/src/linux/raw_browser.rs
+++ b/zeroconf/src/linux/raw_browser.rs
@@ -1,6 +1,6 @@
 //! Rust friendly `AvahiServiceBrowser` wrappers/helpers
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use super::client::ManagedAvahiClient;
 use crate::Result;
@@ -17,7 +17,7 @@ use libc::{c_char, c_void};
 #[derive(Debug)]
 pub struct ManagedAvahiServiceBrowser {
     inner: *mut AvahiServiceBrowser,
-    _client: Arc<ManagedAvahiClient>,
+    _client: Rc<ManagedAvahiClient>,
 }
 
 impl ManagedAvahiServiceBrowser {
@@ -73,7 +73,7 @@ impl Drop for ManagedAvahiServiceBrowser {
 /// [`avahi_service_browser_new()`]: https://avahi.org/doxygen/html/lookup_8h.html#a52d55a5156a7943012d03e6700880d2b
 #[derive(Builder, BuilderDelegate)]
 pub struct ManagedAvahiServiceBrowserParams {
-    client: Arc<ManagedAvahiClient>,
+    client: Rc<ManagedAvahiClient>,
     interface: AvahiIfIndex,
     protocol: AvahiProtocol,
     kind: *const c_char,

--- a/zeroconf/src/linux/resolver.rs
+++ b/zeroconf/src/linux/resolver.rs
@@ -7,7 +7,7 @@ use avahi_sys::{
     AvahiProtocol, AvahiServiceResolver, AvahiServiceResolverCallback,
 };
 use libc::{c_char, c_void};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, rc::Rc};
 
 /// Wraps the `AvahiServiceResolver` type from the raw Avahi bindings.
 ///
@@ -17,7 +17,7 @@ use std::{collections::HashMap, sync::Arc};
 #[derive(Debug)]
 pub struct ManagedAvahiServiceResolver {
     inner: *mut AvahiServiceResolver,
-    _client: Arc<ManagedAvahiClient>,
+    _client: Rc<ManagedAvahiClient>,
 }
 
 impl ManagedAvahiServiceResolver {
@@ -77,7 +77,7 @@ impl Drop for ManagedAvahiServiceResolver {
 /// [`avahi_service_resolver_new()`]: https://avahi.org/doxygen/html/lookup_8h.html#a904611a4134ceb5919f6bb637df84124
 #[derive(Builder, BuilderDelegate)]
 pub struct ManagedAvahiServiceResolverParams {
-    client: Arc<ManagedAvahiClient>,
+    client: Rc<ManagedAvahiClient>,
     interface: AvahiIfIndex,
     protocol: AvahiProtocol,
     name: *const c_char,

--- a/zeroconf/src/macros.rs
+++ b/zeroconf/src/macros.rs
@@ -20,12 +20,6 @@ mod tests {
     use std::ptr;
 
     #[test]
-    fn assert_not_null_non_null_success() {
-        let c_str = c_string!("foo");
-        assert_not_null!(c_str.as_ptr());
-    }
-
-    #[test]
     #[should_panic]
     fn assert_not_null_null_panics() {
         assert_not_null!(ptr::null() as *const c_char);

--- a/zeroconf/src/service_type.rs
+++ b/zeroconf/src/service_type.rs
@@ -49,7 +49,7 @@ impl FromStr for SubType {
         let subtype_part = parts[0];
         let service_kind_part = parts[1];
 
-        if !ServiceType::from_str(service_kind_part).is_ok() {
+        if ServiceType::from_str(service_kind_part).is_err() {
             return Err(format!(
                 "Could not parse SubType component for service kind from {service_kind_part}"
             )

--- a/zeroconf/src/service_type.rs
+++ b/zeroconf/src/service_type.rs
@@ -58,16 +58,7 @@ impl ServiceType {
 
 impl ToString for ServiceType {
     fn to_string(&self) -> String {
-        format!(
-            "_{}._{}{}",
-            self.name,
-            self.protocol,
-            if !self.sub_types.is_empty() {
-                format!(",_{}", self.sub_types.join(",_"))
-            } else {
-                "".to_string()
-            }
-        )
+        format!("_{}._{}", self.name, self.protocol)
     }
 }
 

--- a/zeroconf/src/tests/service_test.rs
+++ b/zeroconf/src/tests/service_test.rs
@@ -3,18 +3,23 @@ use crate::{MdnsBrowser, MdnsService, ServiceType, TxtRecord};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+#[derive(Default, Debug)]
+struct Context {
+    is_discovered: bool,
+    timed_out: bool,
+    txt: Option<TxtRecord>,
+}
+
 #[test]
 fn service_register_is_browsable() {
     super::setup();
 
-    #[derive(Default, Debug)]
-    struct Context {
-        is_discovered: bool,
-        txt: Option<TxtRecord>,
-    }
-
+    const TOTAL_TEST_TIME_S: u64 = 30;
     static SERVICE_NAME: &str = "service_register_is_browsable";
-    let mut service = MdnsService::new(ServiceType::new("http", "tcp").unwrap(), 8080);
+    let mut service = MdnsService::new(
+        ServiceType::with_sub_types("http", "tcp", vec!["printer"]).unwrap(),
+        8080,
+    );
     let context: Arc<Mutex<Context>> = Arc::default();
 
     let mut txt = TxtRecord::new();
@@ -25,48 +30,58 @@ fn service_register_is_browsable() {
     service.set_txt_record(txt.clone());
 
     service.set_registered_callback(Box::new(|_, context| {
-        let mut browser = MdnsBrowser::new(ServiceType::new("http", "tcp").unwrap());
+        let services_to_discover = vec![
+            ServiceType::new("http", "tcp").unwrap(),
+            ServiceType::with_sub_types("http", "tcp", vec!["printer"]).unwrap(),
+        ];
+        for service in services_to_discover {
+            let mut browser = MdnsBrowser::new(service);
 
-        let context = context
-            .as_ref()
-            .unwrap()
-            .downcast_ref::<Arc<Mutex<Context>>>()
-            .unwrap()
-            .clone();
+            let context = context
+                .as_ref()
+                .unwrap()
+                .downcast_ref::<Arc<Mutex<Context>>>()
+                .unwrap()
+                .clone();
 
-        browser.set_context(Box::new(context.clone()));
+            browser.set_context(Box::new(context.clone()));
 
-        browser.set_service_discovered_callback(Box::new(|service, context| {
-            let service = service.unwrap();
+            browser.set_service_discovered_callback(Box::new(|service, context| {
+                let service = service.unwrap();
 
-            if service.name() == SERVICE_NAME {
-                let mut mtx = context
-                    .as_ref()
-                    .unwrap()
-                    .downcast_ref::<Arc<Mutex<Context>>>()
-                    .unwrap()
-                    .lock()
-                    .unwrap();
+                if service.name() == SERVICE_NAME {
+                    let mut mtx = context
+                        .as_ref()
+                        .unwrap()
+                        .downcast_ref::<Arc<Mutex<Context>>>()
+                        .unwrap()
+                        .lock()
+                        .unwrap();
 
-                mtx.txt = service.txt().clone();
-                mtx.is_discovered = true;
+                    mtx.txt = service.txt().clone();
+                    mtx.is_discovered = true;
 
-                debug!("Service discovered");
-            }
-        }));
+                    debug!("Service discovered");
+                }
+            }));
 
-        let event_loop = browser.browse_services().unwrap();
-
-        loop {
-            event_loop.poll(Duration::from_secs(0)).unwrap();
-            if context.lock().unwrap().is_discovered {
-                break;
+            let event_loop = browser.browse_services().unwrap();
+            let browse_start = std::time::Instant::now();
+            loop {
+                event_loop.poll(Duration::from_secs(0)).unwrap();
+                if context.lock().unwrap().is_discovered {
+                    break;
+                }
+                if browse_start.elapsed().as_secs() > TOTAL_TEST_TIME_S / 2 {
+                    context.lock().unwrap().timed_out = true;
+                    break;
+                }
             }
         }
     }));
 
     let event_loop = service.register().unwrap();
-
+    let publish_start = std::time::Instant::now();
     loop {
         event_loop.poll(Duration::from_secs(0)).unwrap();
 
@@ -75,5 +90,11 @@ fn service_register_is_browsable() {
             assert_eq!(txt, mtx.txt.take().unwrap());
             break;
         }
+        if publish_start.elapsed().as_secs() > TOTAL_TEST_TIME_S {
+            mtx.timed_out = true;
+            break;
+        }
     }
+
+    assert!(!context.lock().unwrap().timed_out);
 }


### PR DESCRIPTION
Resolves #30 

Tested, here's a log snippet:
```
[2023-09-13T00:01:24Z DEBUG zeroconf::linux::service] Registering service: AvahiMdnsService { client: None, poll: None, context: AvahiServiceContext { name: None, kind: "_matterc._udp", port: 5540, group: None } }
[2023-09-13T00:01:24Z DEBUG zeroconf::linux::service] Creating group
[2023-09-13T00:01:24Z DEBUG zeroconf::linux::service] Adding service: _matterc._udp
[2023-09-13T00:01:24Z DEBUG zeroconf::linux::service] Adding service subtype: _L250._sub._matterc._udp
[2023-09-13T00:01:24Z DEBUG zeroconf::linux::service] Adding service subtype: _S0._sub._matterc._udp
[2023-09-13T00:01:25Z DEBUG zeroconf::linux::service] Group established
```

And from avahi-browse (snipped extraneous info):
```
$ avahi-browse -t _matterc._udp -r
...
= wlp2s0 IPv6 pop-os                                        _matterc._udp        local
   hostname = [pop-os.local]
   address = [fd4d:e11e:2aab:1:c8b5:684f:3826:6afe]
   port = [5540]
   txt = ["PI=" "PH=33" "SAI=300" "SII=5000" "VP=65521+32768" "DN=TestOnOff" "CM=1" "D=250"]
...
```
