### PR TITLE
Add support for sub-types (cont.)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,11 @@
 {
-    "editor.formatOnSave": true,
-    "cSpell.words": [
-        "aprotocol",
-        "errno",
-        "strlst",
-        "userdata"
-    ]
+  "editor.formatOnSave": true,
+  "cSpell.words": [
+    "aprotocol",
+    "errno",
+    "regtype",
+    "strlst",
+    "unspec",
+    "userdata"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "strlst",
     "unspec",
     "userdata"
-  ]
+  ],
+  "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,7 +99,7 @@ dependencies = [
  "cexpr",
  "cfg-if",
  "clang-sys",
- "clap",
+ "clap 2.33.3",
  "env_logger 0.7.1",
  "lazy_static",
  "lazycell",
@@ -138,6 +186,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,7 +252,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.9.3",
- "syn",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -169,7 +263,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -180,7 +274,7 @@ checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -191,7 +285,7 @@ checksum = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -204,7 +298,7 @@ dependencies = [
  "derive_builder_core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -216,7 +310,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -277,6 +371,12 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -401,11 +501,11 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.23"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -416,9 +516,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -483,7 +583,7 @@ checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -516,6 +616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +630,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -554,6 +671,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +687,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vec_map"
@@ -689,6 +818,7 @@ version = "0.11.1"
 dependencies = [
  "avahi-sys",
  "bonjour-sys",
+ "clap 4.4.4",
  "derive-getters",
  "derive-new",
  "derive_builder",
@@ -706,5 +836,5 @@ name = "zeroconf-macros"
 version = "0.1.2"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.42",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.16",
  "libc",
  "winapi",
 ]
@@ -47,12 +47,12 @@ version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cexpr",
  "cfg-if",
  "clang-sys",
  "clap",
- "env_logger",
+ "env_logger 0.7.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -72,12 +72,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "bonjour-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb769a9e04063943874cd92039ee81eee55adca48bb9615bc3dff73b57cd5aa"
 dependencies = [
  "bindgen",
+ "libc",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
  "libc",
 ]
 
@@ -115,7 +130,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
@@ -211,10 +226,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime 2.1.0",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -239,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,10 +303,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itoa"
@@ -273,9 +345,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libloading"
@@ -288,13 +360,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.11"
+name = "linux-raw-sys"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-dependencies = [
- "cfg-if",
-]
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "maplit"
@@ -373,6 +448,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.38.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -530,6 +618,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "zeroconf"
 version = "0.11.1"
 dependencies = [
@@ -538,7 +692,7 @@ dependencies = [
  "derive-getters",
  "derive-new",
  "derive_builder",
- "env_logger",
+ "env_logger 0.10.0",
  "libc",
  "log",
  "maplit",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -21,12 +21,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.16",
  "libc",
  "winapi",
 ]
@@ -47,12 +95,12 @@ version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cexpr",
  "cfg-if",
  "clang-sys",
- "clap",
- "env_logger",
+ "clap 2.33.3",
+ "env_logger 0.7.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -72,12 +120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "bonjour-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb769a9e04063943874cd92039ee81eee55adca48bb9615bc3dff73b57cd5aa"
 dependencies = [
  "bindgen",
+ "libc",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
  "libc",
 ]
 
@@ -115,12 +178,58 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "darling"
@@ -143,7 +252,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.9.3",
- "syn",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -154,7 +263,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -165,7 +274,7 @@ checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -176,7 +285,7 @@ checksum = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -189,7 +298,7 @@ dependencies = [
  "derive_builder_core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -201,7 +310,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -211,10 +320,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime 2.1.0",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -230,6 +373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +386,12 @@ checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "humantime"
@@ -248,10 +403,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "lazy_static"
@@ -267,9 +439,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libloading"
@@ -282,13 +454,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.11"
+name = "linux-raw-sys"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-dependencies = [
- "cfg-if",
-]
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -314,11 +489,11 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -329,9 +504,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -361,6 +536,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.38.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,7 +565,7 @@ checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -399,6 +587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,10 +604,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.0"
+name = "syn"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -437,6 +642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +658,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vec_map"
@@ -501,6 +718,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "zeroconf"
 version = "0.11.1"
 dependencies = [
@@ -519,6 +802,9 @@ dependencies = [
 name = "zeroconf-browser-example"
 version = "0.1.0"
 dependencies = [
+ "clap 4.4.4",
+ "env_logger 0.10.0",
+ "log",
  "zeroconf",
 ]
 
@@ -527,12 +813,14 @@ name = "zeroconf-macros"
 version = "0.1.2"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.41",
 ]
 
 [[package]]
 name = "zeroconf-service-example"
 version = "0.1.0"
 dependencies = [
+ "env_logger 0.10.0",
+ "log",
  "zeroconf",
 ]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
 name = "zeroconf-service-example"
 version = "0.1.0"
 dependencies = [
+ "clap 4.4.4",
  "env_logger 0.10.0",
  "log",
  "zeroconf",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,2 @@
 [workspace]
-members = [
-    "browser",
-    "service",
-]
+members = ["browser", "service"]

--- a/examples/browser/Cargo.toml
+++ b/examples/browser/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2018"
 
 [dependencies]
 zeroconf = { path = "../../zeroconf" }
+env_logger = "0.10.0"
+log = "0.4.20"
+clap = { version = "4.4.4", features = ["derive"] }

--- a/examples/browser/src/main.rs
+++ b/examples/browser/src/main.rs
@@ -5,7 +5,8 @@ use zeroconf::prelude::*;
 use zeroconf::{MdnsBrowser, ServiceDiscovery, ServiceType};
 
 fn main() {
-    let mut browser = MdnsBrowser::new(ServiceType::new("http", "tcp").unwrap());
+    let mut browser =
+        MdnsBrowser::new(ServiceType::with_sub_types("http", "tcp", vec!["printer1"]).unwrap());
 
     browser.set_service_discovered_callback(Box::new(on_service_discovered));
 

--- a/examples/browser/src/main.rs
+++ b/examples/browser/src/main.rs
@@ -1,12 +1,49 @@
+#[macro_use]
+extern crate log;
+
+use clap::Parser;
+
 use std::any::Any;
 use std::sync::Arc;
 use std::time::Duration;
 use zeroconf::prelude::*;
 use zeroconf::{MdnsBrowser, ServiceDiscovery, ServiceType};
 
+/// Example of a simple mDNS browser
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// Name of the service type to browse
+    #[clap(short, long, default_value = "http")]
+    name: String,
+
+    /// Protocol of the service type to browse
+    #[clap(short, long, default_value = "tcp")]
+    protocol: String,
+
+    /// Sub-type of the service type to browse
+    #[clap(short, long)]
+    sub_type: Option<String>,
+}
+
 fn main() {
-    let mut browser =
-        MdnsBrowser::new(ServiceType::with_sub_types("http", "tcp", vec!["printer1"]).unwrap());
+    env_logger::init();
+
+    let Args {
+        name,
+        protocol,
+        sub_type,
+    } = Args::parse();
+
+    let sub_types: Vec<&str> = match sub_type.as_ref() {
+        Some(sub_type) => vec![sub_type],
+        None => vec![],
+    };
+
+    let service_type =
+        ServiceType::with_sub_types(&name, &protocol, sub_types).expect("invalid service type");
+
+    let mut browser = MdnsBrowser::new(service_type);
 
     browser.set_service_discovered_callback(Box::new(on_service_discovered));
 
@@ -22,7 +59,7 @@ fn on_service_discovered(
     result: zeroconf::Result<ServiceDiscovery>,
     _context: Option<Arc<dyn Any>>,
 ) {
-    println!("Service discovered: {:?}", result.unwrap());
+    info!("Service discovered: {:?}", result.unwrap());
 
     // ...
 }

--- a/examples/service/Cargo.toml
+++ b/examples/service/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2018"
 
 [dependencies]
 zeroconf = { path = "../../zeroconf" }
+env_logger = "0.10.0"
+log = "0.4.20"

--- a/examples/service/Cargo.toml
+++ b/examples/service/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 zeroconf = { path = "../../zeroconf" }
 env_logger = "0.10.0"
 log = "0.4.20"
+clap = { version = "4.4.4", features = ["derive"] }

--- a/examples/service/src/main.rs
+++ b/examples/service/src/main.rs
@@ -10,7 +10,11 @@ pub struct Context {
 }
 
 fn main() {
-    let mut service = MdnsService::new(ServiceType::new("http", "tcp").unwrap(), 8080);
+    let mut service = MdnsService::new(
+        ServiceType::with_sub_types("http", "tcp", vec!["printer1", "printer2"]).unwrap(),
+        8080,
+    );
+
     let mut txt_record = TxtRecord::new();
     let context: Arc<Mutex<Context>> = Arc::default();
 

--- a/examples/service/src/main.rs
+++ b/examples/service/src/main.rs
@@ -1,11 +1,29 @@
 #[macro_use]
 extern crate log;
 
+use clap::Parser;
+
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use zeroconf::prelude::*;
 use zeroconf::{MdnsService, ServiceRegistration, ServiceType, TxtRecord};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// Name of the service type to register
+    #[clap(short, long, default_value = "http")]
+    name: String,
+
+    /// Protocol of the service type to register
+    #[clap(short, long, default_value = "tcp")]
+    protocol: String,
+
+    /// Sub-types of the service type to register
+    #[clap(short, long)]
+    sub_types: Vec<String>,
+}
 
 #[derive(Default, Debug)]
 pub struct Context {
@@ -15,11 +33,15 @@ pub struct Context {
 fn main() {
     env_logger::init();
 
-    let mut service = MdnsService::new(
-        ServiceType::with_sub_types("http", "tcp", vec!["printer1", "printer2"]).unwrap(),
-        8080,
-    );
+    let Args {
+        name,
+        protocol,
+        sub_types,
+    } = Args::parse();
 
+    let sub_types = sub_types.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+    let service_type = ServiceType::with_sub_types(&name, &protocol, sub_types).unwrap();
+    let mut service = MdnsService::new(service_type, 8080);
     let mut txt_record = TxtRecord::new();
     let context: Arc<Mutex<Context>> = Arc::default();
 

--- a/examples/service/src/main.rs
+++ b/examples/service/src/main.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate log;
+
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -10,6 +13,8 @@ pub struct Context {
 }
 
 fn main() {
+    env_logger::init();
+
     let mut service = MdnsService::new(
         ServiceType::with_sub_types("http", "tcp", vec!["printer1", "printer2"]).unwrap(),
         8080,
@@ -39,7 +44,7 @@ fn on_service_registered(
 ) {
     let service = result.unwrap();
 
-    println!("Service registered: {:?}", service);
+    info!("Service registered: {:?}", service);
 
     let context = context
         .as_ref()
@@ -50,7 +55,7 @@ fn on_service_registered(
 
     context.lock().unwrap().service_name = service.name().clone();
 
-    println!("Context: {:?}", context);
+    info!("Context: {:?}", context);
 
     // ...
 }

--- a/zeroconf/Cargo.toml
+++ b/zeroconf/Cargo.toml
@@ -31,6 +31,7 @@ zeroconf-macros = { path = "../zeroconf-macros", version = "0.1.2" }
 env_logger = "0.10.0"
 maplit = "1.0.2"
 serde_json = "1.0.57"
+clap = { version = "4.4.4", features = ["derive"] }
 
 [target.'cfg(unix)'.dependencies]
 avahi-sys = "0.10.0"

--- a/zeroconf/Cargo.toml
+++ b/zeroconf/Cargo.toml
@@ -23,12 +23,12 @@ serde = { version = "1.0.116", features = ["derive"] }
 derive-getters = "0.2.0"
 derive_builder = "0.9.0"
 derive-new = "0.5.8"
-log = "0.4.11"
+log = "0.4.20"
 libc = "0.2.77"
 zeroconf-macros = { path = "../zeroconf-macros", version = "0.1.2" }
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.10.0"
 maplit = "1.0.2"
 serde_json = "1.0.57"
 

--- a/zeroconf/src/ffi/mod.rs
+++ b/zeroconf/src/ffi/mod.rs
@@ -47,7 +47,7 @@ pub trait UnwrapOrNull<T> {
 
 impl<T> UnwrapOrNull<T> for Option<*const T> {
     fn unwrap_or_null(&self) -> *const T {
-        self.unwrap_or_else(|| ptr::null() as *const T)
+        self.unwrap_or_else(ptr::null)
     }
 }
 
@@ -59,7 +59,7 @@ pub trait UnwrapMutOrNull<T> {
 
 impl<T> UnwrapMutOrNull<T> for Option<*mut T> {
     fn unwrap_mut_or_null(&mut self) -> *mut T {
-        self.unwrap_or_else(|| ptr::null_mut() as *mut T)
+        self.unwrap_or_else(ptr::null_mut)
     }
 }
 

--- a/zeroconf/src/linux/avahi_util.rs
+++ b/zeroconf/src/linux/avahi_util.rs
@@ -70,6 +70,22 @@ pub fn format_service_type(service_type: &ServiceType) -> String {
     format!("_{}._{}", service_type.name(), service_type.protocol())
 }
 
+/// Formats the specified `ServiceType` as a `String` for browsing Avahi services
+pub fn format_browser_type(service_type: &ServiceType) -> String {
+    let kind = format_service_type(service_type);
+    let sub_types = service_type.sub_types();
+
+    if sub_types.len() == 0 {
+        return kind;
+    }
+
+    if sub_types.len() > 1 {
+        warn!("browsing by multiple sub-types is not supported on Avahi devices, using first sub-type only");
+    }
+
+    format_sub_type(&sub_types[0], &kind)
+}
+
 /// Formats the specified `sub_type` string as a `String` for use with Avahi
 pub fn format_sub_type(sub_type: &str, kind: &str) -> String {
     format!(

--- a/zeroconf/src/linux/avahi_util.rs
+++ b/zeroconf/src/linux/avahi_util.rs
@@ -75,7 +75,7 @@ pub fn format_browser_type(service_type: &ServiceType) -> String {
     let kind = format_service_type(service_type);
     let sub_types = service_type.sub_types();
 
-    if sub_types.len() == 0 {
+    if sub_types.is_empty() {
         return kind;
     }
 

--- a/zeroconf/src/linux/browser.rs
+++ b/zeroconf/src/linux/browser.rs
@@ -46,7 +46,7 @@ impl TMdnsBrowser for AvahiMdnsBrowser {
             client: None,
             poll: None,
             browser: None,
-            kind: c_string!(avahi_util::format_service_type(&service_type)),
+            kind: c_string!(avahi_util::format_browser_type(&service_type)),
             context: Box::default(),
             interface_index: avahi_sys::AVAHI_IF_UNSPEC,
         }

--- a/zeroconf/src/linux/browser.rs
+++ b/zeroconf/src/linux/browser.rs
@@ -41,11 +41,16 @@ pub struct AvahiMdnsBrowser {
 
 impl TMdnsBrowser for AvahiMdnsBrowser {
     fn new(service_type: ServiceType) -> Self {
+        let kind = if service_type.sub_types().is_empty() {
+            c_string!(service_type.to_string())
+        } else {
+            c_string!(service_type.sub_types()[0].to_string())
+        };
         Self {
             client: None,
             poll: None,
             browser: None,
-            kind: c_string!(service_type.to_string()),
+            kind,
             context: Box::default(),
             interface_index: avahi_sys::AVAHI_IF_UNSPEC,
         }

--- a/zeroconf/src/linux/browser.rs
+++ b/zeroconf/src/linux/browser.rs
@@ -42,16 +42,11 @@ pub struct AvahiMdnsBrowser {
 
 impl TMdnsBrowser for AvahiMdnsBrowser {
     fn new(service_type: ServiceType) -> Self {
-        let kind = if service_type.sub_types().is_empty() {
-            c_string!(service_type.to_string())
-        } else {
-            c_string!(service_type.sub_types()[0].to_string())
-        };
         Self {
             client: None,
             poll: None,
             browser: None,
-            kind,
+            kind: c_string!(avahi_util::format_service_type(&service_type)),
             context: Box::default(),
             interface_index: avahi_sys::AVAHI_IF_UNSPEC,
         }

--- a/zeroconf/src/linux/client.rs
+++ b/zeroconf/src/linux/client.rs
@@ -89,6 +89,7 @@ pub struct ManagedAvahiClientParams {
 pub(super) unsafe fn get_host_name<'a>(client: *mut AvahiClient) -> Result<&'a str> {
     assert_not_null!(client);
     let host_name = avahi_client_get_host_name(client);
+
     if !host_name.is_null() {
         Ok(c_str::raw_to_str(host_name))
     } else {

--- a/zeroconf/src/linux/client.rs
+++ b/zeroconf/src/linux/client.rs
@@ -1,6 +1,6 @@
 //! Rust friendly `AvahiClient` wrappers/helpers
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use super::avahi_util;
 use super::poll::ManagedAvahiSimplePoll;
@@ -19,7 +19,7 @@ use libc::{c_int, c_void};
 #[derive(Debug)]
 pub struct ManagedAvahiClient {
     pub(crate) inner: *mut AvahiClient,
-    _poll: Arc<ManagedAvahiSimplePoll>,
+    _poll: Rc<ManagedAvahiSimplePoll>,
 }
 
 impl ManagedAvahiClient {
@@ -80,7 +80,7 @@ impl Drop for ManagedAvahiClient {
 /// [`avahi_client_new()`]: https://avahi.org/doxygen/html/client_8h.html#a07b2a33a3e7cbb18a0eb9d00eade6ae6
 #[derive(Builder, BuilderDelegate)]
 pub struct ManagedAvahiClientParams {
-    poll: Arc<ManagedAvahiSimplePoll>,
+    poll: Rc<ManagedAvahiSimplePoll>,
     flags: AvahiClientFlags,
     callback: AvahiClientCallback,
     userdata: *mut c_void,

--- a/zeroconf/src/linux/entry_group.rs
+++ b/zeroconf/src/linux/entry_group.rs
@@ -1,6 +1,6 @@
 //! Rust friendly `AvahiEntryGroup` wrappers/helpers
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use super::{client::ManagedAvahiClient, string_list::ManagedAvahiStringList};
 use crate::ffi::UnwrapMutOrNull;
@@ -21,7 +21,7 @@ use libc::{c_char, c_void};
 #[derive(Debug)]
 pub struct ManagedAvahiEntryGroup {
     inner: *mut AvahiEntryGroup,
-    _client: Arc<ManagedAvahiClient>,
+    _client: Rc<ManagedAvahiClient>,
 }
 
 impl ManagedAvahiEntryGroup {
@@ -153,7 +153,7 @@ impl Drop for ManagedAvahiEntryGroup {
 /// [avahi_entry_group_new()]: https://avahi.org/doxygen/html/publish_8h.html#abb17598f2b6ec3c3f69defdd488d568c
 #[derive(Builder, BuilderDelegate)]
 pub struct ManagedAvahiEntryGroupParams {
-    client: Arc<ManagedAvahiClient>,
+    client: Rc<ManagedAvahiClient>,
     callback: AvahiEntryGroupCallback,
     userdata: *mut c_void,
 }

--- a/zeroconf/src/linux/event_loop.rs
+++ b/zeroconf/src/linux/event_loop.rs
@@ -4,12 +4,12 @@ use super::poll::ManagedAvahiSimplePoll;
 use crate::event_loop::TEventLoop;
 use crate::Result;
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::rc::Rc;
 use std::time::Duration;
 
 #[derive(new)]
 pub struct AvahiEventLoop<'a> {
-    poll: Arc<ManagedAvahiSimplePoll>,
+    poll: Rc<ManagedAvahiSimplePoll>,
     phantom: PhantomData<&'a ManagedAvahiSimplePoll>,
 }
 

--- a/zeroconf/src/linux/raw_browser.rs
+++ b/zeroconf/src/linux/raw_browser.rs
@@ -1,6 +1,6 @@
 //! Rust friendly `AvahiServiceBrowser` wrappers/helpers
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use super::client::ManagedAvahiClient;
 use crate::Result;
@@ -17,7 +17,7 @@ use libc::{c_char, c_void};
 #[derive(Debug)]
 pub struct ManagedAvahiServiceBrowser {
     inner: *mut AvahiServiceBrowser,
-    _client: Arc<ManagedAvahiClient>,
+    _client: Rc<ManagedAvahiClient>,
 }
 
 impl ManagedAvahiServiceBrowser {
@@ -73,7 +73,7 @@ impl Drop for ManagedAvahiServiceBrowser {
 /// [`avahi_service_browser_new()`]: https://avahi.org/doxygen/html/lookup_8h.html#a52d55a5156a7943012d03e6700880d2b
 #[derive(Builder, BuilderDelegate)]
 pub struct ManagedAvahiServiceBrowserParams {
-    client: Arc<ManagedAvahiClient>,
+    client: Rc<ManagedAvahiClient>,
     interface: AvahiIfIndex,
     protocol: AvahiProtocol,
     kind: *const c_char,

--- a/zeroconf/src/linux/resolver.rs
+++ b/zeroconf/src/linux/resolver.rs
@@ -7,7 +7,7 @@ use avahi_sys::{
     AvahiProtocol, AvahiServiceResolver, AvahiServiceResolverCallback,
 };
 use libc::{c_char, c_void};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, rc::Rc};
 
 /// Wraps the `AvahiServiceResolver` type from the raw Avahi bindings.
 ///
@@ -17,7 +17,7 @@ use std::{collections::HashMap, sync::Arc};
 #[derive(Debug)]
 pub struct ManagedAvahiServiceResolver {
     inner: *mut AvahiServiceResolver,
-    _client: Arc<ManagedAvahiClient>,
+    _client: Rc<ManagedAvahiClient>,
 }
 
 impl ManagedAvahiServiceResolver {
@@ -77,7 +77,7 @@ impl Drop for ManagedAvahiServiceResolver {
 /// [`avahi_service_resolver_new()`]: https://avahi.org/doxygen/html/lookup_8h.html#a904611a4134ceb5919f6bb637df84124
 #[derive(Builder, BuilderDelegate)]
 pub struct ManagedAvahiServiceResolverParams {
-    client: Arc<ManagedAvahiClient>,
+    client: Rc<ManagedAvahiClient>,
     interface: AvahiIfIndex,
     protocol: AvahiProtocol,
     name: *const c_char,

--- a/zeroconf/src/macos/bonjour_util.rs
+++ b/zeroconf/src/macos/bonjour_util.rs
@@ -57,13 +57,9 @@ pub fn format_regtype(service_type: ServiceType) -> CString {
     c_string!(regtype.join(","))
 }
 
+/// Parses the specified `&str` into a `ServiceType`
 pub fn parse_regtype(regtype: &str) -> Result<ServiceType> {
     let types = regtype.split(',').collect::<Vec<_>>();
-
-    if types.len() == 0 {
-        return Err("could not parse Bonjour regtype into ServiceType".into());
-    }
-
     let parts = types[0].split('.').collect::<Vec<_>>();
 
     if parts.len() != 2 {
@@ -93,6 +89,30 @@ fn lstrip_underscore(s: &str) -> &str {
 mod tests {
     use super::*;
     use crate::ServiceType;
+
+    #[test]
+    fn parse_regtype_success() {
+        assert_eq!(
+            parse_regtype("_http._tcp,_printer1,_printer2").unwrap(),
+            ServiceType::with_sub_types("http", "tcp", vec!["printer1", "printer2"]).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_regtype_success_no_subtypes() {
+        assert_eq!(
+            parse_regtype("_http._tcp").unwrap(),
+            ServiceType::new("http", "tcp").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_regtype_failure_invalid_regtype() {
+        assert_eq!(
+            parse_regtype("foobar"),
+            Err("invalid name and protocol".into())
+        );
+    }
 
     #[test]
     fn format_regtype_success() {

--- a/zeroconf/src/macos/bonjour_util.rs
+++ b/zeroconf/src/macos/bonjour_util.rs
@@ -33,9 +33,9 @@ pub fn sys_exec<F: FnOnce() -> DNSServiceErrorType>(func: F, message: &str) -> R
     let err = func();
 
     if err < 0 {
-        Result::Err(format!("{} (code: {})", message, err).into())
+        Err(format!("{} (code: {})", message, err).into())
     } else {
-        Result::Ok(())
+        Ok(())
     }
 }
 

--- a/zeroconf/src/macos/bonjour_util.rs
+++ b/zeroconf/src/macos/bonjour_util.rs
@@ -40,7 +40,7 @@ pub fn sys_exec<F: FnOnce() -> DNSServiceErrorType>(func: F, message: &str) -> R
 }
 
 /// Formats the specified `ServiceType` as a `CString` for use with Bonjour
-pub fn format_regtype(service_type: ServiceType) -> CString {
+pub fn format_regtype(service_type: &ServiceType) -> CString {
     let mut regtype = vec![format!(
         "_{}._{}",
         service_type.name(),
@@ -59,6 +59,8 @@ pub fn format_regtype(service_type: ServiceType) -> CString {
 
 /// Parses the specified `&str` into a `ServiceType`
 pub fn parse_regtype(regtype: &str) -> Result<ServiceType> {
+    // TODO: use shared func
+
     let types = regtype.split(',').collect::<Vec<_>>();
     let parts = types[0].split('.').collect::<Vec<_>>();
 
@@ -75,14 +77,6 @@ pub fn parse_regtype(regtype: &str) -> Result<ServiceType> {
         .collect::<Result<Vec<_>>>()?;
 
     ServiceType::with_sub_types(name, protocol, sub_types)
-}
-
-fn lstrip_underscore(s: &str) -> &str {
-    if let Some(stripped) = s.strip_prefix('_') {
-        stripped
-    } else {
-        s
-    }
 }
 
 #[cfg(test)]

--- a/zeroconf/src/macos/bonjour_util.rs
+++ b/zeroconf/src/macos/bonjour_util.rs
@@ -60,7 +60,7 @@ pub fn format_regtype(service_type: &ServiceType) -> CString {
 /// Parses the specified `&str` into a `ServiceType`
 pub fn parse_regtype(regtype: &str) -> Result<ServiceType> {
     let types = regtype.split(',').collect::<Vec<_>>();
-    let service_type = ServiceType::from_str(&types[0])?;
+    let service_type = ServiceType::from_str(types[0])?;
 
     let sub_types = types[1..]
         .iter()

--- a/zeroconf/src/macos/bonjour_util.rs
+++ b/zeroconf/src/macos/bonjour_util.rs
@@ -1,7 +1,9 @@
 //! Utilities related to Bonjour
 
+use std::ffi::CString;
+
 use super::constants;
-use crate::NetworkInterface;
+use crate::{check_valid_characters, NetworkInterface, Result, ServiceType};
 use bonjour_sys::DNSServiceErrorType;
 
 /// Normalizes the specified domain `&str` to conform to a standard enforced by this crate.
@@ -27,12 +29,122 @@ pub fn interface_index(interface: NetworkInterface) -> u32 {
 }
 
 /// Executes the specified closure and returns a formatted `Result`
-pub fn sys_exec<F: FnOnce() -> DNSServiceErrorType>(func: F, message: &str) -> crate::Result<()> {
+pub fn sys_exec<F: FnOnce() -> DNSServiceErrorType>(func: F, message: &str) -> Result<()> {
     let err = func();
 
     if err < 0 {
-        crate::Result::Err(format!("{} (code: {})", message, err).into())
+        Result::Err(format!("{} (code: {})", message, err).into())
     } else {
-        crate::Result::Ok(())
+        Result::Ok(())
+    }
+}
+
+/// Formats the specified `ServiceType` as a `CString` for use with Bonjour
+pub fn format_regtype(service_type: ServiceType) -> CString {
+    let mut regtype = vec![format!(
+        "_{}._{}",
+        service_type.name(),
+        service_type.protocol()
+    )];
+
+    regtype.extend(
+        service_type
+            .sub_types()
+            .iter()
+            .map(|sub_type| format!("_{sub_type}")),
+    );
+
+    c_string!(regtype.join(","))
+}
+
+pub fn parse_regtype(regtype: &str) -> Result<ServiceType> {
+    let types = regtype.split(',').collect::<Vec<_>>();
+
+    if types.len() == 0 {
+        return Err("could not parse Bonjour regtype into ServiceType".into());
+    }
+
+    let parts = types[0].split('.').collect::<Vec<_>>();
+
+    if parts.len() != 2 {
+        return Err("invalid name and protocol".into());
+    }
+
+    let name = lstrip_underscore(check_valid_characters(parts[0])?);
+    let protocol = lstrip_underscore(check_valid_characters(parts[1])?);
+
+    let sub_types = types[1..]
+        .iter()
+        .map(|s| check_valid_characters(lstrip_underscore(s)))
+        .collect::<Result<Vec<_>>>()?;
+
+    ServiceType::with_sub_types(name, protocol, sub_types)
+}
+
+fn lstrip_underscore(s: &str) -> &str {
+    if let Some(stripped) = s.strip_prefix('_') {
+        stripped
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ServiceType;
+
+    #[test]
+    fn format_regtype_success() {
+        assert_eq!(
+            format_regtype(
+                ServiceType::with_sub_types("http", "tcp", vec!["printer1", "printer2"]).unwrap()
+            ),
+            c_string!("_http._tcp,_printer1,_printer2")
+        );
+    }
+
+    #[test]
+    fn format_regtype_success_no_subtypes() {
+        assert_eq!(
+            format_regtype(ServiceType::new("http", "tcp").unwrap()),
+            c_string!("_http._tcp")
+        );
+    }
+
+    #[test]
+    fn sys_exec_returns_error() {
+        assert_eq!(
+            sys_exec(|| -42, "uh oh spaghetti-o"),
+            Err("uh oh spaghetti-o (code: -42)".into())
+        );
+    }
+
+    #[test]
+    fn sys_exec_returns_ok() {
+        assert_eq!(sys_exec(|| 0, "success"), Ok(()));
+    }
+
+    #[test]
+    fn network_interface_unspec_maps_to_bonjour_if_unspec() {
+        assert_eq!(interface_index(NetworkInterface::Unspec), 0);
+    }
+
+    #[test]
+    fn network_interface_at_index_maps_to_index() {
+        assert_eq!(interface_index(NetworkInterface::AtIndex(42)), 42);
+    }
+
+    #[test]
+    fn normalize_domain_removes_trailing_dot() {
+        assert_eq!(
+            normalize_domain("foo.bar.baz."),
+            String::from("foo.bar.baz")
+        );
+    }
+
+    #[test]
+    fn normalize_domain_does_not_remove_trailing_dot_if_not_present() {
+        assert_eq!(normalize_domain("foo.bar.baz"), String::from("foo.bar.baz"));
     }
 }

--- a/zeroconf/src/macos/browser.rs
+++ b/zeroconf/src/macos/browser.rs
@@ -30,7 +30,7 @@ impl TMdnsBrowser for BonjourMdnsBrowser {
     fn new(service_type: ServiceType) -> Self {
         Self {
             service: Arc::default(),
-            kind: bonjour_util::format_regtype(service_type),
+            kind: bonjour_util::format_regtype(&service_type),
             interface_index: constants::BONJOUR_IF_UNSPEC,
             context: Box::default(),
         }

--- a/zeroconf/src/macos/browser.rs
+++ b/zeroconf/src/macos/browser.rs
@@ -16,7 +16,6 @@ use std::ffi::CString;
 use std::fmt::{self, Formatter};
 use std::net::IpAddr;
 use std::ptr;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -31,7 +30,7 @@ impl TMdnsBrowser for BonjourMdnsBrowser {
     fn new(service_type: ServiceType) -> Self {
         Self {
             service: Arc::default(),
-            kind: c_string!(service_type.to_string()),
+            kind: bonjour_util::format_regtype(service_type),
             interface_index: constants::BONJOUR_IF_UNSPEC,
             context: Box::default(),
         }
@@ -263,7 +262,7 @@ unsafe fn handle_get_address_info(
 
     let result = ServiceDiscovery::builder()
         .name(ctx.resolved_name.take().unwrap())
-        .service_type(ServiceType::from_str(&kind)?)
+        .service_type(bonjour_util::parse_regtype(&kind)?)
         .domain(domain)
         .host_name(hostname)
         .address(ip)

--- a/zeroconf/src/macos/service.rs
+++ b/zeroconf/src/macos/service.rs
@@ -32,7 +32,7 @@ impl TMdnsService for BonjourMdnsService {
     fn new(service_type: ServiceType, port: u16) -> Self {
         Self {
             service: Arc::default(),
-            kind: bonjour_util::format_regtype(service_type),
+            kind: bonjour_util::format_regtype(&service_type),
             port,
             name: None,
             domain: None,

--- a/zeroconf/src/macos/service.rs
+++ b/zeroconf/src/macos/service.rs
@@ -13,7 +13,6 @@ use bonjour_sys::{DNSServiceErrorType, DNSServiceFlags, DNSServiceRef};
 use libc::{c_char, c_void};
 use std::any::Any;
 use std::ffi::CString;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -33,7 +32,7 @@ impl TMdnsService for BonjourMdnsService {
     fn new(service_type: ServiceType, port: u16) -> Self {
         Self {
             service: Arc::default(),
-            kind: c_string!(service_type.to_string()),
+            kind: bonjour_util::format_regtype(service_type),
             port,
             name: None,
             domain: None,
@@ -164,7 +163,7 @@ unsafe fn handle_register(
 
     let result = ServiceRegistration::builder()
         .name(c_str::copy_raw(name))
-        .service_type(ServiceType::from_str(&kind)?)
+        .service_type(bonjour_util::parse_regtype(&kind)?)
         .domain(domain)
         .build()
         .expect("could not build ServiceRegistration");

--- a/zeroconf/src/macros.rs
+++ b/zeroconf/src/macros.rs
@@ -20,12 +20,6 @@ mod tests {
     use std::ptr;
 
     #[test]
-    fn assert_not_null_non_null_success() {
-        let c_str = c_string!("foo");
-        assert_not_null!(c_str.as_ptr());
-    }
-
-    #[test]
     #[should_panic]
     fn assert_not_null_null_panics() {
         assert_not_null!(ptr::null() as *const c_char);

--- a/zeroconf/src/macros.rs
+++ b/zeroconf/src/macros.rs
@@ -20,6 +20,12 @@ mod tests {
     use std::ptr;
 
     #[test]
+    fn assert_not_null_non_null_success() {
+        let c_str = c_string!("foo");
+        assert_not_null!(c_str.as_ptr());
+    }
+
+    #[test]
     #[should_panic]
     fn assert_not_null_null_panics() {
         assert_not_null!(ptr::null() as *const c_char);

--- a/zeroconf/src/service_type.rs
+++ b/zeroconf/src/service_type.rs
@@ -49,7 +49,7 @@ impl FromStr for SubType {
         let subtype_part = parts[0];
         let service_kind_part = parts[1];
 
-        if !ServiceType::from_str(service_kind_part).is_ok() {
+        if ServiceType::from_str(service_kind_part).is_err() {
             return Err(format!(
                 "Could not parse SubType component for service kind from {service_kind_part}"
             )

--- a/zeroconf/src/service_type.rs
+++ b/zeroconf/src/service_type.rs
@@ -1,74 +1,13 @@
 //! Data type for constructing a service type
 
 use crate::Result;
-use std::str::FromStr;
-
-/// Data type for representing a service subtype to register as part of an mDNS service.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct SubType {
-    // The string containing the subtype data
-    subtype: String,
-    // The service type
-    kind: String,
-}
-
-impl SubType {
-    fn new(subtype: &str, kind: &str) -> Result<Self> {
-        let subtype = check_valid_characters(subtype)?;
-        Ok(Self {
-            subtype: subtype.to_owned(),
-            kind: kind.to_owned(),
-        })
-    }
-}
-
-impl ToString for SubType {
-    fn to_string(&self) -> String {
-        format!(
-            "{}{}._sub.{}",
-            if self.subtype.starts_with('_') {
-                ""
-            } else {
-                "_"
-            },
-            self.subtype,
-            self.kind
-        )
-    }
-}
-
-impl FromStr for SubType {
-    type Err = crate::error::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        let parts: Vec<&str> = s.split("._sub.").collect();
-        if parts.len() != 2 {
-            return Err(format!("Could not parse SubType from {s}").into());
-        }
-
-        let subtype_part = parts[0];
-        let service_kind_part = parts[1];
-
-        if ServiceType::from_str(service_kind_part).is_err() {
-            return Err(format!(
-                "Could not parse SubType component for service kind from {service_kind_part}"
-            )
-            .into());
-        }
-
-        Ok(Self {
-            subtype: subtype_part.to_owned(),
-            kind: service_kind_part.to_owned(),
-        })
-    }
-}
 
 /// Data type for constructing a service type to register as an mDNS service.
 #[derive(Default, Debug, Getters, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ServiceType {
     name: String,
     protocol: String,
-    sub_types: Vec<SubType>,
+    sub_types: Vec<String>,
 }
 
 impl ServiceType {
@@ -84,50 +23,18 @@ impl ServiceType {
     /// Creates a new `ServiceType` with the specified name (e.g. `http`) and protocol (e.g. `tcp`)
     /// and sub-types.
     pub fn with_sub_types(name: &str, protocol: &str, sub_types: Vec<&str>) -> Result<Self> {
-        let mut service_type = Self {
-            name: name.to_string(),
-            protocol: protocol.to_string(),
-            sub_types: vec![],
-        };
-        service_type.sub_types = sub_types
-            .into_iter()
-            .map(|subtype| SubType::new(subtype, &service_type.to_string()))
-            .collect::<Result<Vec<_>>>()?;
-        Ok(service_type)
+        Ok(Self {
+            name: check_valid_characters(name)?.to_string(),
+            protocol: check_valid_characters(protocol)?.to_string(),
+            sub_types: sub_types
+                .into_iter()
+                .map(|s| check_valid_characters(s).map(|valid| valid.to_string()))
+                .collect::<Result<Vec<_>>>()?,
+        })
     }
 }
 
-impl ToString for ServiceType {
-    fn to_string(&self) -> String {
-        format!("_{}._{}", self.name, self.protocol)
-    }
-}
-
-impl FromStr for ServiceType {
-    type Err = crate::error::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        let parts: Vec<&str> = s.split('.').collect();
-        if parts.len() != 2 {
-            return Err("invalid name and protocol".into());
-        }
-
-        let name = lstrip_underscore(check_valid_characters(parts[0])?);
-        let protocol = lstrip_underscore(check_valid_characters(parts[1])?);
-
-        ServiceType::new(name, protocol)
-    }
-}
-
-fn lstrip_underscore(s: &str) -> &str {
-    if let Some(stripped) = s.strip_prefix('_') {
-        stripped
-    } else {
-        s
-    }
-}
-
-fn check_valid_characters(part: &str) -> Result<&str> {
+pub fn check_valid_characters(part: &str) -> Result<&str> {
     if part.contains('.') {
         Err("invalid character: .".into())
     } else if part.contains(',') {
@@ -151,57 +58,5 @@ mod tests {
         ServiceType::new("http", ",tcp").expect_err("invalid character: ,");
         ServiceType::new("", "tcp").expect_err("cannot be empty");
         ServiceType::new("http", "").expect_err("cannot be empty");
-    }
-
-    #[test]
-    fn must_have_name_and_protocol() {
-        ServiceType::from_str("_http").expect_err("invalid name and protocol");
-    }
-
-    #[test]
-    fn to_string_success() {
-        assert_eq!(
-            ServiceType::new("http", "tcp").unwrap().to_string(),
-            "_http._tcp"
-        );
-    }
-
-    #[test]
-    fn to_string_with_sub_types_success() {
-        let service_type =
-            ServiceType::with_sub_types("http", "tcp", vec!["api-v1", "api-v2"]).unwrap();
-        assert_eq!(service_type.to_string(), "_http._tcp");
-
-        assert_eq!(service_type.sub_types()[0].kind, "_http._tcp");
-        assert_eq!(service_type.sub_types()[0].subtype, "api-v1");
-        assert_eq!(
-            service_type.sub_types()[0].to_string(),
-            "_api-v1._sub._http._tcp"
-        );
-
-        assert_eq!(service_type.sub_types()[1].kind, "_http._tcp");
-        assert_eq!(service_type.sub_types()[1].subtype, "api-v2");
-        assert_eq!(
-            service_type.sub_types()[1].to_string(),
-            "_api-v2._sub._http._tcp"
-        );
-    }
-
-    #[test]
-    fn from_str_success() {
-        assert_eq!(
-            ServiceType::from_str("_http._tcp").unwrap(),
-            ServiceType::new("http", "tcp").unwrap()
-        );
-    }
-
-    #[test]
-    fn from_str_with_sub_types_err() {
-        ServiceType::from_str("_http._tcp,api-v1,api-v2").expect_err("Subtype format invalid");
-    }
-
-    #[test]
-    fn from_str_subtype_success() {
-        SubType::from_str("_printer._sub._http._tcp").unwrap();
     }
 }

--- a/zeroconf/src/service_type.rs
+++ b/zeroconf/src/service_type.rs
@@ -1,6 +1,8 @@
 //! Data type for constructing a service type
 
-use crate::Result;
+use std::str::FromStr;
+
+use crate::{error::Error, Result};
 
 /// Data type for constructing a service type to register as an mDNS service.
 #[derive(Default, Debug, Getters, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -34,6 +36,23 @@ impl ServiceType {
     }
 }
 
+impl FromStr for ServiceType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let parts = s.split('.').collect::<Vec<_>>();
+
+        if parts.len() != 2 {
+            return Err("invalid name and protocol".into());
+        }
+
+        let name = lstrip_underscore(check_valid_characters(parts[0])?);
+        let protocol = lstrip_underscore(check_valid_characters(parts[1])?);
+
+        Self::new(name, protocol)
+    }
+}
+
 pub fn check_valid_characters(part: &str) -> Result<&str> {
     if part.contains('.') {
         Err("invalid character: .".into())
@@ -43,6 +62,14 @@ pub fn check_valid_characters(part: &str) -> Result<&str> {
         Err("cannot be empty".into())
     } else {
         Ok(part)
+    }
+}
+
+pub fn lstrip_underscore(s: &str) -> &str {
+    if let Some(stripped) = s.strip_prefix('_') {
+        stripped
+    } else {
+        s
     }
 }
 

--- a/zeroconf/src/service_type.rs
+++ b/zeroconf/src/service_type.rs
@@ -58,16 +58,7 @@ impl ServiceType {
 
 impl ToString for ServiceType {
     fn to_string(&self) -> String {
-        format!(
-            "_{}._{}{}",
-            self.name,
-            self.protocol,
-            if !self.sub_types.is_empty() {
-                format!(",_{}", self.sub_types.join(",_"))
-            } else {
-                "".to_string()
-            }
-        )
+        format!("_{}._{}", self.name, self.protocol)
     }
 }
 

--- a/zeroconf/src/tests/service_test.rs
+++ b/zeroconf/src/tests/service_test.rs
@@ -16,10 +16,12 @@ fn service_register_is_browsable() {
 
     const TOTAL_TEST_TIME_S: u64 = 30;
     static SERVICE_NAME: &str = "service_register_is_browsable";
+
     let mut service = MdnsService::new(
         ServiceType::with_sub_types("http", "tcp", vec!["printer"]).unwrap(),
         8080,
     );
+
     let context: Arc<Mutex<Context>> = Arc::default();
 
     let mut txt = TxtRecord::new();
@@ -34,6 +36,7 @@ fn service_register_is_browsable() {
             ServiceType::new("http", "tcp").unwrap(),
             ServiceType::with_sub_types("http", "tcp", vec!["printer"]).unwrap(),
         ];
+
         for service in services_to_discover {
             let mut browser = MdnsBrowser::new(service);
 
@@ -67,11 +70,14 @@ fn service_register_is_browsable() {
 
             let event_loop = browser.browse_services().unwrap();
             let browse_start = std::time::Instant::now();
+
             loop {
                 event_loop.poll(Duration::from_secs(0)).unwrap();
+
                 if context.lock().unwrap().is_discovered {
                     break;
                 }
+
                 if browse_start.elapsed().as_secs() > TOTAL_TEST_TIME_S / 2 {
                     context.lock().unwrap().timed_out = true;
                     break;
@@ -82,14 +88,17 @@ fn service_register_is_browsable() {
 
     let event_loop = service.register().unwrap();
     let publish_start = std::time::Instant::now();
+
     loop {
         event_loop.poll(Duration::from_secs(0)).unwrap();
 
         let mut mtx = context.lock().unwrap();
+
         if mtx.is_discovered {
             assert_eq!(txt, mtx.txt.take().unwrap());
             break;
         }
+
         if publish_start.elapsed().as_secs() > TOTAL_TEST_TIME_S {
             mtx.timed_out = true;
             break;

--- a/zeroconf/src/tests/service_test.rs
+++ b/zeroconf/src/tests/service_test.rs
@@ -3,18 +3,23 @@ use crate::{MdnsBrowser, MdnsService, ServiceType, TxtRecord};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+#[derive(Default, Debug)]
+struct Context {
+    is_discovered: bool,
+    timed_out: bool,
+    txt: Option<TxtRecord>,
+}
+
 #[test]
 fn service_register_is_browsable() {
     super::setup();
 
-    #[derive(Default, Debug)]
-    struct Context {
-        is_discovered: bool,
-        txt: Option<TxtRecord>,
-    }
-
+    const TOTAL_TEST_TIME_S: u64 = 30;
     static SERVICE_NAME: &str = "service_register_is_browsable";
-    let mut service = MdnsService::new(ServiceType::new("http", "tcp").unwrap(), 8080);
+    let mut service = MdnsService::new(
+        ServiceType::with_sub_types("http", "tcp", vec!["printer"]).unwrap(),
+        8080,
+    );
     let context: Arc<Mutex<Context>> = Arc::default();
 
     let mut txt = TxtRecord::new();
@@ -25,48 +30,58 @@ fn service_register_is_browsable() {
     service.set_txt_record(txt.clone());
 
     service.set_registered_callback(Box::new(|_, context| {
-        let mut browser = MdnsBrowser::new(ServiceType::new("http", "tcp").unwrap());
+        let services_to_discover = vec![
+            ServiceType::new("http", "tcp").unwrap(),
+            ServiceType::with_sub_types("http", "tcp", vec!["printer"]).unwrap(),
+        ];
+        for service in services_to_discover {
+            let mut browser = MdnsBrowser::new(service);
 
-        let context = context
-            .as_ref()
-            .unwrap()
-            .downcast_ref::<Arc<Mutex<Context>>>()
-            .unwrap()
-            .clone();
+            let context = context
+                .as_ref()
+                .unwrap()
+                .downcast_ref::<Arc<Mutex<Context>>>()
+                .unwrap()
+                .clone();
 
-        browser.set_context(Box::new(context.clone()));
+            browser.set_context(Box::new(context.clone()));
 
-        browser.set_service_discovered_callback(Box::new(|service, context| {
-            let service = service.unwrap();
+            browser.set_service_discovered_callback(Box::new(|service, context| {
+                let service = service.unwrap();
 
-            if service.name() == SERVICE_NAME {
-                let mut mtx = context
-                    .as_ref()
-                    .unwrap()
-                    .downcast_ref::<Arc<Mutex<Context>>>()
-                    .unwrap()
-                    .lock()
-                    .unwrap();
+                if service.name() == SERVICE_NAME {
+                    let mut mtx = context
+                        .as_ref()
+                        .unwrap()
+                        .downcast_ref::<Arc<Mutex<Context>>>()
+                        .unwrap()
+                        .lock()
+                        .unwrap();
 
-                mtx.txt = service.txt().clone();
-                mtx.is_discovered = true;
+                    mtx.txt = service.txt().clone();
+                    mtx.is_discovered = true;
 
-                debug!("Service discovered");
-            }
-        }));
+                    debug!("Service discovered");
+                }
+            }));
 
-        let event_loop = browser.browse_services().unwrap();
-
-        loop {
-            event_loop.poll(Duration::from_secs(0)).unwrap();
-            if context.lock().unwrap().is_discovered {
-                break;
+            let event_loop = browser.browse_services().unwrap();
+            let browse_start = std::time::Instant::now();
+            loop {
+                event_loop.poll(Duration::from_secs(0)).unwrap();
+                if context.lock().unwrap().is_discovered {
+                    break;
+                }
+                if browse_start.elapsed().as_secs() > TOTAL_TEST_TIME_S / 2 {
+                    context.lock().unwrap().timed_out = true;
+                    break;
+                }
             }
         }
     }));
 
     let event_loop = service.register().unwrap();
-
+    let publish_start = std::time::Instant::now();
     loop {
         event_loop.poll(Duration::from_secs(0)).unwrap();
 
@@ -75,5 +90,11 @@ fn service_register_is_browsable() {
             assert_eq!(txt, mtx.txt.take().unwrap());
             break;
         }
+        if publish_start.elapsed().as_secs() > TOTAL_TEST_TIME_S {
+            mtx.timed_out = true;
+            break;
+        }
     }
+
+    assert!(!context.lock().unwrap().timed_out);
 }


### PR DESCRIPTION
Supersedes #31

Resolves #30

Thank you @ssnover for your contribution.

This PR includes the addition of sub-types on Avahi devices which was previously lacking. I've tested this for interoperability between Avahi and Bonjour devices and it seems to be working.

## Browsing a service by sub-type from Avahi published by Bonjour

macOS:

```bash
$ cd ./examples/service
$ RUST_LOG=debug cargo run -- -s printer
   Compiling zeroconf-service-example v0.1.0 (/Users/walker/code/zeroconf-rs/examples/service)
    Finished dev [unoptimized + debuginfo] target(s) in 1.17s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `/Users/walker/code/zeroconf-rs/examples/target/debug/zeroconf-service-example -s printer`
[2023-09-23T20:16:34Z DEBUG zeroconf::macos::service] Registering service: BonjourMdnsService { service: Mutex { data: ManagedDNSServiceRef(0x0), poisoned: false, .. }, kind: "_http._tcp,_printer", port: 8080, name: Some("zeroconf_example_service"), domain: None, host: None, interface_index: 0, txt_record: Some(TxtRecord { data: {"foo": "bar"} }), context: BonjourServiceContext { user_context: Some(Any { .. }) } }
[2023-09-23T20:16:35Z INFO  zeroconf_service_example] Service registered: ServiceRegistration { name: "zeroconf_example_service", service_type: ServiceType { name: "http", protocol: "tcp", sub_types: [] }, domain: "local" }
[2023-09-23T20:16:35Z INFO  zeroconf_service_example] Context: Mutex { data: Context { service_name: "zeroconf_example_service" }, poisoned: false, .. }
```

Linux:

```bash
$ cd ./examples/browser
$ RUST_LOG=debug cargo run -- -s printer
   Compiling zeroconf v0.11.1 (/home/walker/code/personal/zeroconf-rs/zeroconf)
   Compiling zeroconf-browser-example v0.1.0 (/home/walker/code/personal/zeroconf-rs/examples/browser)
    Finished dev [unoptimized + debuginfo] target(s) in 0.85s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `/home/walker/code/personal/zeroconf-rs/examples/target/debug/zeroconf-browser-example -s printer`
[2023-09-23T20:19:18Z DEBUG zeroconf::linux::browser] Browsing services: AvahiMdnsBrowser { client: None, poll: None, browser: None, kind: "_printer._sub._http._tcp", interface_index: -1, context: AvahiBrowserContext { client: None, resolvers: ServiceResolverSet { resolvers: {} } } }
[2023-09-23T20:19:18Z DEBUG zeroconf::linux::browser] Service resolved: ServiceDiscovery { name: "zeroconf_example_service", service_type: ServiceType { name: "http", protocol: "tcp", sub_types: [] }, domain: "local", host_name: "Walkers-MacBook-Pro.local", address: "192.168.0.80", port: 8080, txt: Some(TxtRecord { data: {"foo": "bar"} }) }
[2023-09-23T20:19:18Z INFO  zeroconf_browser_example] Service discovered: ServiceDiscovery { name: "zeroconf_example_service", service_type: ServiceType { name: "http", protocol: "tcp", sub_types: [] }, domain: "local", host_name: "Walkers-MacBook-Pro.local", address: "192.168.0.80", port: 8080, txt: Some(TxtRecord { data: {"foo": "bar"} }) }
```

## Browsing a service by sub-type from Bonjour published by Avahi

Linux:

```bash
cd ./examples/service
$ RUST_LOG=debug cargo run -- -s printer
   Compiling zeroconf-service-example v0.1.0 (/home/walker/code/personal/zeroconf-rs/examples/service)
    Finished dev [unoptimized + debuginfo] target(s) in 0.70s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `/home/walker/code/personal/zeroconf-rs/examples/target/debug/zeroconf-service-example -s printer`
[2023-09-23T20:20:28Z DEBUG zeroconf::linux::service] Registering service: AvahiMdnsService { client: None, poll: None, context: AvahiServiceContext { name: Some("zeroconf_example_service"), kind: "_http._tcp", port: 8080, group: None } }
[2023-09-23T20:20:28Z DEBUG zeroconf::linux::service] Creating group
[2023-09-23T20:20:28Z DEBUG zeroconf::linux::service] Adding service: _http._tcp
[2023-09-23T20:20:28Z DEBUG zeroconf::linux::service] Adding service subtype: _printer._sub._http._tcp
```

Bonjour:

```bash
cd ./examples/browser
RUST_LOG=debug cargo run -- -s printer
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `/Users/walker/code/zeroconf-rs/examples/target/debug/zeroconf-browser-example -s printer`
[2023-09-23T20:25:02Z DEBUG zeroconf::macos::browser] Browsing services: BonjourMdnsBrowser { service: Mutex { data: ManagedDNSServiceRef(0x0), poisoned: false, .. }, kind: "_http._tcp,_printer", interface_index: 0, context: BonjourResolverContext { resolved_name: None, resolved_kind: None, resolved_domain: None, resolved_port: 0 } }
[2023-09-23T20:25:02Z INFO  zeroconf_browser_example] Service discovered: ServiceDiscovery { name: "zeroconf_example_service", service_type: ServiceType { name: "http", protocol: "tcp", sub_types: [] }, domain: "local", host_name: "picard.local.", address: "0.0.0.0", port: 8080, txt: Some(TxtRecord { data: {"foo": "bar"} }) }
```

Note: When I try to browse for services with an unregistered sub-type, there are no results, as expected.