### PR TITLE
Normalize consistency of unsafe in function contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 such as [Bonjour] or [Avahi], providing an easy and idiomatic way to both register and
 browse services.
 
+Check-out [zeroconf-tokio](https://github.com/windy1/zeroconf-tokio) if you are interested in using `zeroconf` in an
+async setting.
+
 ## Prerequisites
 
 On Linux:

--- a/zeroconf/src/avahi/client.rs
+++ b/zeroconf/src/avahi/client.rs
@@ -24,7 +24,10 @@ pub struct ManagedAvahiClient {
 impl ManagedAvahiClient {
     /// Initializes the underlying `*mut AvahiClient` and verifies it was created; returning
     /// `Err(String)` if unsuccessful.
-    pub fn new(
+    ///
+    /// # Safety
+    /// This function is unsafe because of the raw pointer dereference.
+    pub unsafe fn new(
         ManagedAvahiClientParams {
             poll,
             flags,
@@ -34,15 +37,13 @@ impl ManagedAvahiClient {
     ) -> Result<Self> {
         let mut err: c_int = 0;
 
-        let inner = unsafe {
-            avahi_client_new(
-                avahi_simple_poll_get(poll.inner()),
-                flags,
-                callback,
-                userdata,
-                &mut err,
-            )
-        };
+        let inner = avahi_client_new(
+            avahi_simple_poll_get(poll.inner()),
+            flags,
+            callback,
+            userdata,
+            &mut err,
+        );
 
         if inner.is_null() {
             return Err("could not initialize AvahiClient".into());
@@ -61,8 +62,11 @@ impl ManagedAvahiClient {
     /// Delegate function for [`avahi_client_get_host_name()`].
     ///
     /// [`avahi_client_get_host_name()`]: https://avahi.org/doxygen/html/client_8h.html#a89378618c3c592a255551c308ba300bf
-    pub fn host_name<'a>(&self) -> Result<&'a str> {
-        unsafe { get_host_name(self.inner) }
+    ///
+    /// # Safety
+    /// This function is unsafe because of the raw pointer dereference.
+    pub unsafe fn host_name<'a>(&self) -> Result<&'a str> {
+        get_host_name(self.inner)
     }
 }
 

--- a/zeroconf/src/avahi/entry_group.rs
+++ b/zeroconf/src/avahi/entry_group.rs
@@ -27,17 +27,20 @@ pub struct ManagedAvahiEntryGroup {
 impl ManagedAvahiEntryGroup {
     /// Initializes the underlying `*mut AvahiEntryGroup` and verifies it was created; returning
     /// `Err(String)` if unsuccessful.
-    pub fn new(
+    ///
+    /// # Safety
+    /// This function is unsafe because of the raw pointer dereference.
+    pub unsafe fn new(
         ManagedAvahiEntryGroupParams {
             client,
             callback,
             userdata,
         }: ManagedAvahiEntryGroupParams,
     ) -> Result<Self> {
-        let inner = unsafe { avahi_entry_group_new(client.inner, callback, userdata) };
+        let inner = avahi_entry_group_new(client.inner, callback, userdata);
 
         if inner.is_null() {
-            let err = avahi_util::get_error(unsafe { avahi_client_errno(client.inner) });
+            let err = avahi_util::get_error(avahi_client_errno(client.inner));
             Err(format!("could not initialize AvahiEntryGroup: {}", err).into())
         } else {
             Ok(Self {
@@ -50,8 +53,11 @@ impl ManagedAvahiEntryGroup {
     /// Delegate function for [`avahi_entry_group_is_empty()`].
     ///
     /// [`avahi_entry_group_is_empty()`]: https://avahi.org/doxygen/html/publish_8h.html#af5a78ee1fda6678970536889d459d85c
-    pub fn is_empty(&self) -> bool {
-        unsafe { avahi_entry_group_is_empty(self.inner) != 0 }
+    ///
+    /// # Safety
+    /// This function is unsafe because of the call to `avahi_entry_group_is_empty()`.
+    pub unsafe fn is_empty(&self) -> bool {
+        avahi_entry_group_is_empty(self.inner) != 0
     }
 
     /// Delegate function for [`avahi_entry_group_add_service()`].
@@ -59,7 +65,10 @@ impl ManagedAvahiEntryGroup {
     /// Also propagates any error returned into a `Result`.
     ///
     /// [`avahi_entry_group_add_service()`]: https://avahi.org/doxygen/html/publish_8h.html#acb05a7d3d23a3b825ca77cb1c7d00ce4
-    pub fn add_service(
+    ///
+    /// # Safety
+    /// This function is unsafe because of the call to `avahi_entry_group_add_service_strlst()`.
+    pub unsafe fn add_service(
         &mut self,
         AddServiceParams {
             interface,
@@ -74,7 +83,7 @@ impl ManagedAvahiEntryGroup {
         }: AddServiceParams,
     ) -> Result<()> {
         avahi_util::sys_exec(
-            || unsafe {
+            || {
                 avahi_entry_group_add_service_strlst(
                     self.inner,
                     interface,
@@ -97,7 +106,10 @@ impl ManagedAvahiEntryGroup {
     /// Also propagates any error returned into a `Result`.
     ///
     /// [`avahi_entry_group_add_service_subtype()`]: https://avahi.org/doxygen/html/publish_8h.html#a93841be69a152d3134b408c25bb4d5d5
-    pub fn add_service_subtype(
+    ///
+    /// # Safety
+    /// This function is unsafe because of the call to `avahi_entry_group_add_service_subtype()`.
+    pub unsafe fn add_service_subtype(
         &mut self,
         AddServiceSubtypeParams {
             interface,
@@ -110,7 +122,7 @@ impl ManagedAvahiEntryGroup {
         }: AddServiceSubtypeParams,
     ) -> Result<()> {
         avahi_util::sys_exec(
-            || unsafe {
+            || {
                 avahi_entry_group_add_service_subtype(
                     self.inner, interface, protocol, flags, name, kind, domain, subtype,
                 )
@@ -124,9 +136,12 @@ impl ManagedAvahiEntryGroup {
     /// Also propagates any error returned into a `Result`.
     ///
     /// [`avahi_entry_group_commit()`]: https://avahi.org/doxygen/html/publish_8h.html#a2375338d23af4281399404758840a2de
-    pub fn commit(&mut self) -> Result<()> {
+    ///
+    /// # Safety
+    /// This function is unsafe because of the call to `avahi_entry_group_commit()`.
+    pub unsafe fn commit(&mut self) -> Result<()> {
         avahi_util::sys_exec(
-            || unsafe { avahi_entry_group_commit(self.inner) },
+            || avahi_entry_group_commit(self.inner),
             "could not commit service",
         )
     }
@@ -134,8 +149,11 @@ impl ManagedAvahiEntryGroup {
     /// Delegate function for [`avahi_entry_group_reset()`].
     ///
     /// [`avahi_entry_group_reset()`]: https://avahi.org/doxygen/html/publish_8h.html#a1293bbccf878dbeb9916660022bc71b2
-    pub fn reset(&mut self) {
-        unsafe { avahi_entry_group_reset(self.inner) };
+    ///
+    /// # Safety
+    /// This function is unsafe because of the call to `avahi_entry_group_reset()`.
+    pub unsafe fn reset(&mut self) {
+        avahi_entry_group_reset(self.inner);
     }
 
     /// Delegate function for [`avahi_entry_group_get_client()`].

--- a/zeroconf/src/avahi/event_loop.rs
+++ b/zeroconf/src/avahi/event_loop.rs
@@ -19,6 +19,6 @@ impl TEventLoop for AvahiEventLoop {
     /// does not respect the `timeout` parameter, the `timeout` passed
     /// here will have no effect -- ie will return immediately.
     fn poll(&self, timeout: Duration) -> Result<()> {
-        self.poll.iterate(timeout)
+        unsafe { self.poll.iterate(timeout) }
     }
 }

--- a/zeroconf/src/avahi/poll.rs
+++ b/zeroconf/src/avahi/poll.rs
@@ -18,8 +18,11 @@ pub struct ManagedAvahiSimplePoll(*mut AvahiSimplePoll);
 impl ManagedAvahiSimplePoll {
     /// Initializes the underlying `*mut AvahiSimplePoll` and verifies it was created; returning
     /// `Err(String)` if unsuccessful
-    pub fn new() -> Result<Self> {
-        let poll = unsafe { avahi_simple_poll_new() };
+    ///
+    /// # Safety
+    /// This function is unsafe because of the raw pointer dereference.
+    pub unsafe fn new() -> Result<Self> {
+        let poll = avahi_simple_poll_new();
         if poll.is_null() {
             Err("could not initialize AvahiSimplePoll".into())
         } else {
@@ -30,9 +33,12 @@ impl ManagedAvahiSimplePoll {
     /// Delegate function for [`avahi_simple_poll_loop()`].
     ///
     /// [`avahi_simple_poll_loop()`]: https://avahi.org/doxygen/html/simple-watch_8h.html#a14b4cb29832e8c3de609d4c4e5611985
-    pub fn start_loop(&self) -> Result<()> {
+    ///
+    /// # Safety
+    /// This function is unsafe because of the call to `avahi_simple_poll_loop()`.
+    pub unsafe fn start_loop(&self) -> Result<()> {
         avahi_util::sys_exec(
-            || unsafe { avahi_simple_poll_loop(self.0) },
+            || avahi_simple_poll_loop(self.0),
             "could not start AvahiSimplePoll",
         )
     }
@@ -40,14 +46,17 @@ impl ManagedAvahiSimplePoll {
     /// Delegate function for [`avahi_simple_poll_iterate()`].
     ///
     /// [`avahi_simple_poll_iterate()`]: https://avahi.org/doxygen/html/simple-watch_8h.html#ad5b7c9d3b7a6584d609241ee6f472a2e
-    pub fn iterate(&self, timeout: Duration) -> Result<()> {
+    ///
+    /// # Safety
+    /// This function is unsafe because of the call to `avahi_simple_poll_iterate()`.
+    pub unsafe fn iterate(&self, timeout: Duration) -> Result<()> {
         let sleep_time: i32 = timeout
             .as_millis() // `avahi_simple_poll_iterate()` expects `sleep_time` in msecs.
             .try_into() // `avahi_simple_poll_iterate()` expects `sleep_time` as an i32.
             .unwrap_or(i32::MAX); // if converting to an i32 overflows, just use the largest number we can.
 
         // Returns -1 on error, 0 on success and 1 if a quit request has been scheduled
-        match unsafe { avahi_simple_poll_iterate(self.0, sleep_time) } {
+        match avahi_simple_poll_iterate(self.0, sleep_time) {
             0 | 1 => Ok(()),
             -1 => Err(Error::from(
                 "avahi_simple_poll_iterate(..) threw an error result",

--- a/zeroconf/src/avahi/raw_browser.rs
+++ b/zeroconf/src/avahi/raw_browser.rs
@@ -25,7 +25,10 @@ pub struct ManagedAvahiServiceBrowser {
 impl ManagedAvahiServiceBrowser {
     /// Initializes the underlying `*mut AvahiClient` and verifies it was created; returning
     /// `Err(String)` if unsuccessful.
-    pub fn new(
+    ///
+    /// # Safety
+    /// This function is unsafe because of the raw pointer dereference.
+    pub unsafe fn new(
         ManagedAvahiServiceBrowserParams {
             client,
             interface,
@@ -37,18 +40,16 @@ impl ManagedAvahiServiceBrowser {
             userdata,
         }: ManagedAvahiServiceBrowserParams,
     ) -> Result<Self> {
-        let inner = unsafe {
-            avahi_service_browser_new(
-                client.inner,
-                interface,
-                protocol,
-                kind,
-                domain,
-                flags,
-                callback,
-                userdata,
-            )
-        };
+        let inner = avahi_service_browser_new(
+            client.inner,
+            interface,
+            protocol,
+            kind,
+            domain,
+            flags,
+            callback,
+            userdata,
+        );
 
         if inner.is_null() {
             Err("could not initialize Avahi service browser".into())

--- a/zeroconf/src/avahi/resolver.rs
+++ b/zeroconf/src/avahi/resolver.rs
@@ -24,7 +24,10 @@ pub struct ManagedAvahiServiceResolver {
 impl ManagedAvahiServiceResolver {
     /// Initializes the underlying `*mut AvahiServiceResolver` and verifies it was created;
     /// returning `Err(String)` if unsuccessful.
-    pub fn new(
+    ///
+    /// # Safety
+    /// This function is unsafe because of the raw pointer dereference.
+    pub unsafe fn new(
         ManagedAvahiServiceResolverParams {
             client,
             interface,
@@ -38,20 +41,18 @@ impl ManagedAvahiServiceResolver {
             userdata,
         }: ManagedAvahiServiceResolverParams,
     ) -> Result<Self> {
-        let inner = unsafe {
-            avahi_service_resolver_new(
-                client.inner,
-                interface,
-                protocol,
-                name,
-                kind,
-                domain,
-                aprotocol,
-                flags,
-                callback,
-                userdata,
-            )
-        };
+        let inner = avahi_service_resolver_new(
+            client.inner,
+            interface,
+            protocol,
+            name,
+            kind,
+            domain,
+            aprotocol,
+            flags,
+            callback,
+            userdata,
+        );
 
         if inner.is_null() {
             Err("could not initialize AvahiServiceResolver".into())

--- a/zeroconf/src/bonjour/event_loop.rs
+++ b/zeroconf/src/bonjour/event_loop.rs
@@ -22,10 +22,11 @@ impl TEventLoop for BonjourEventLoop {
             .service
             .lock()
             .expect("should have been able to obtain lock on service ref");
+
         let select = unsafe { ffi::bonjour::read_select(service.sock_fd(), timeout)? };
 
         if select > 0 {
-            service.process_result()
+            unsafe { service.process_result() }
         } else {
             Ok(())
         }

--- a/zeroconf/src/bonjour/service_ref.rs
+++ b/zeroconf/src/bonjour/service_ref.rs
@@ -31,7 +31,10 @@ impl ManagedDNSServiceRef {
     /// Delegate function for [`DNSServiceRegister`].
     ///
     /// [`DNSServiceRegister`]: https://developer.apple.com/documentation/dnssd/1804733-dnsserviceregister?language=objc
-    pub fn register_service(
+    ///
+    /// # Safety
+    /// This function is unsafe because it calls a C function.
+    pub unsafe fn register_service(
         &mut self,
         RegisterServiceParams {
             flags,
@@ -48,7 +51,7 @@ impl ManagedDNSServiceRef {
         }: RegisterServiceParams,
     ) -> Result<()> {
         bonjour_util::sys_exec(
-            || unsafe {
+            || {
                 DNSServiceRegister(
                     &mut self.0 as *mut DNSServiceRef,
                     flags,
@@ -71,7 +74,10 @@ impl ManagedDNSServiceRef {
     /// Delegate function for [`DNSServiceBrowse`].
     ///
     /// [`DNSServiceBrowse`]: https://developer.apple.com/documentation/dnssd/1804742-dnsservicebrowse?language=objc
-    pub fn browse_services(
+    ///
+    /// # Safety
+    /// This function is unsafe because it calls a C function.
+    pub unsafe fn browse_services(
         &mut self,
         BrowseServicesParams {
             flags,
@@ -83,7 +89,7 @@ impl ManagedDNSServiceRef {
         }: BrowseServicesParams,
     ) -> Result<()> {
         bonjour_util::sys_exec(
-            || unsafe {
+            || {
                 DNSServiceBrowse(
                     &mut self.0 as *mut DNSServiceRef,
                     flags,
@@ -101,7 +107,10 @@ impl ManagedDNSServiceRef {
     /// Delegate function fro [`DNSServiceResolve`].
     ///
     /// [`DNSServiceResolve`]: https://developer.apple.com/documentation/dnssd/1804744-dnsserviceresolve?language=objc
-    pub fn resolve_service(
+    ///
+    /// # Safety
+    /// This function is unsafe because it calls a C function.
+    pub unsafe fn resolve_service(
         &mut self,
         ServiceResolveParams {
             flags,
@@ -114,7 +123,7 @@ impl ManagedDNSServiceRef {
         }: ServiceResolveParams,
     ) -> Result<()> {
         bonjour_util::sys_exec(
-            || unsafe {
+            || {
                 DNSServiceResolve(
                     &mut self.0 as *mut DNSServiceRef,
                     flags,
@@ -135,7 +144,10 @@ impl ManagedDNSServiceRef {
     /// Delegate function for [`DNSServiceGetAddrInfo`].
     ///
     /// [`DNSServiceGetAddrInfo`]: https://developer.apple.com/documentation/dnssd/1804700-dnsservicegetaddrinfo?language=objc
-    pub fn get_address_info(
+    ///
+    /// # Safety
+    /// This function is unsafe because it calls a C function.
+    pub unsafe fn get_address_info(
         &mut self,
         GetAddressInfoParams {
             flags,
@@ -147,7 +159,7 @@ impl ManagedDNSServiceRef {
         }: GetAddressInfoParams,
     ) -> Result<()> {
         bonjour_util::sys_exec(
-            || unsafe {
+            || {
                 DNSServiceGetAddrInfo(
                     &mut self.0 as *mut DNSServiceRef,
                     flags,
@@ -167,9 +179,12 @@ impl ManagedDNSServiceRef {
     /// Delegate function for [`DNSServiceProcessResult`].
     ///
     /// [`DNSServiceProcessResult`]: https://developer.apple.com/documentation/dnssd/1804696-dnsserviceprocessresult?language=objc
-    pub fn process_result(&self) -> Result<()> {
+    ///
+    /// # Safety
+    /// This function is unsafe because it calls a C function.
+    pub unsafe fn process_result(&self) -> Result<()> {
         bonjour_util::sys_exec(
-            || unsafe { DNSServiceProcessResult(self.0) },
+            || DNSServiceProcessResult(self.0),
             "could not process service result",
         )
     }
@@ -177,8 +192,11 @@ impl ManagedDNSServiceRef {
     /// Delegate function for [`DNSServiceRefSockFD`].
     ///
     /// [`DNSServiceRefSockFD`]: https://developer.apple.com/documentation/dnssd/1804698-dnsservicerefsockfd?language=objc
-    pub fn sock_fd(&self) -> dnssd_sock_t {
-        unsafe { DNSServiceRefSockFD(self.0) }
+    ///
+    /// # Safety
+    /// This function is unsafe because it calls a C function.
+    pub unsafe fn sock_fd(&self) -> dnssd_sock_t {
+        DNSServiceRefSockFD(self.0)
     }
 }
 

--- a/zeroconf/src/bonjour/txt_record.rs
+++ b/zeroconf/src/bonjour/txt_record.rs
@@ -9,12 +9,11 @@ use std::ffi::CString;
 use std::{ptr, slice};
 
 /// Interface for interfacing with Bonjour's TXT record capabilities.
-#[derive(Clone)]
 pub struct BonjourTxtRecord(ManagedTXTRecordRef);
 
 impl TTxtRecord for BonjourTxtRecord {
     fn new() -> Self {
-        Self(ManagedTXTRecordRef::new())
+        Self(unsafe { ManagedTXTRecordRef::new() })
     }
 
     fn insert(&mut self, key: &str, value: &str) -> Result<()> {
@@ -67,7 +66,7 @@ impl TTxtRecord for BonjourTxtRecord {
     }
 
     fn len(&self) -> usize {
-        self.0.get_count() as usize
+        unsafe { self.0.get_count() as usize }
     }
 
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (String, String)> + 'a> {
@@ -80,6 +79,12 @@ impl TTxtRecord for BonjourTxtRecord {
 
     fn values<'a>(&'a self) -> Box<dyn Iterator<Item = String> + 'a> {
         Box::new(Values(Iter::new(self)))
+    }
+}
+
+impl Clone for BonjourTxtRecord {
+    fn clone(&self) -> Self {
+        Self(unsafe { self.0.clone() })
     }
 }
 


### PR DESCRIPTION
## What

This PR normalizes the consistency of where the `unsafe` boundary is, marking functions of the implementation-level interfaces `unsafe` if they use unsafe functionality.

## Why
The goal here is to make the boundary of `unsafe` more well defined between implementation-level details and the library-level interfaces that are provided to the end user; and, makes clear that, these implementation-level interfaces do not provide the guarantees that the library-level ones do.

## Manual Tests
Tested on macOS, Windows, and Linux

## Documentation Updates
n/a