### PR TITLE
Don't panic if avahiString fails on .as_str

### DIFF
--- a/zeroconf/Cargo.toml
+++ b/zeroconf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroconf"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Walker Crouse <walkercrouse@hotmail.com>"]
 edition = "2018"
 description = "cross-platform library that wraps ZeroConf/mDNS implementations like Bonjour or Avahi"

--- a/zeroconf/src/avahi/txt_record.rs
+++ b/zeroconf/src/avahi/txt_record.rs
@@ -138,15 +138,16 @@ impl Iterator for Iter<'_> {
         let pair = unsafe { n.get_pair() };
         self.node = unsafe { n.next() };
 
-        let key = unsafe { pair.key().as_str() }
-            .expect("could not key as str")
-            .to_string();
-
-        let value = unsafe { pair.value().as_str() }
-            .expect("could not get value as str")
-            .to_string();
-
-        Some((key, value))
+        if let Some(key) = unsafe { pair.key().as_str() } {
+            let key = key.to_string();
+            if let Some(value) = unsafe { pair.value().as_str() } {
+                return Some((key, value.to_string()));
+            } else {
+                return None;
+            }
+        } else {
+            return None;
+        }
     }
 }
 


### PR DESCRIPTION
## What
As described in #74 some malformed packets cause a runtime panic. This PR aims to drop such malformed packets

## Why
IMHO, its unacceptable for a library to crash the process using it

## Manual Tests
After this patch  my binary now does not crash

## Documentation Updates
This is simple error case handling, I'm not sure any documentation will help anyone 
